### PR TITLE
add google-analytics img-src to config file

### DIFF
--- a/config/csp.php
+++ b/config/csp.php
@@ -51,6 +51,7 @@ return [
         'google analytics' => [
             'connect-src' => ['www.google-analytics.com'],
             'script-src' => ['www.google-analytics.com', 'www.googletagmanager.com'],
+            'img-src' => ['www.google-analytics.com'],
         ],
 
         /*


### PR DESCRIPTION
Google Analytics also requires `img-src` to allow its domain.

I don't really know why, but I guess it had a 1px image somewhere to allow tracking without javascript.

Anyway, without allowing it inside the CSP header, it'll return an error.