### PR TITLE
Small typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Don't forget to set the `policy` key in the `csp` config file to the class name 
 
 ### Using inline scripts and styles
 
-When using CSP you must specifically allow the use of inline scripts or styles. The recommended way of doing that with this package is to use a `nonce`. A nonce is a number that iss unique per request. The nonce must be specified in the CSP headers and in an attribute on the html tag. This way an attacker has no way of injecting malicious scripts or styles.
+When using CSP you must specifically allow the use of inline scripts or styles. The recommended way of doing that with this package is to use a `nonce`. A nonce is a number that is unique per request. The nonce must be specified in the CSP headers and in an attribute on the html tag. This way an attacker has no way of injecting malicious scripts or styles.
 
 First you must add the nonce to the right directives in your policy:
 


### PR DESCRIPTION
`iss` -> `is`