### PR TITLE
also allow php 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.0
   - 7.1
   - 7.2
 

--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,13 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.0|^7.1",
         "illuminate/http": "~5.5.0|~5.6.0",
         "illuminate/support": "~5.5.0|~5.6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
-        "orchestra/testbench": "~3.5|~3.6"
+        "orchestra/testbench": "~3.5|~3.6",
+        "phpunit/phpunit": "^6.5|^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
In https://github.com/spatie/laravel-csp/issues/19 the question about the minimum PHP version has been raised. This PR solves it by:

* extending the min PHP version constraint
* extending the min phpunit version constraint