### PR TITLE
Hashes auto-enclosed into quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,25 +104,28 @@ This package allows you to define CSP policies. A CSP policy determines which CS
 
 An example of a CSP directive is `script-src`. If this has the value `'self' www.google.com` then your site can only load scripts from it's own domain of `www.google.com`. You'll find [a list with all CSP directives](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/#Directives) at Mozilla's excellent developer site.
 
-According to the spec certain directive values need to be surrounded by quotes. Examples of this are `'self'`, `'none'` and `'unsafe-inline'`. When using `addDirective` function you're not required to surround the directive value with quotes manually. We will automatically add quotes.
+According to the spec certain directive values need to be surrounded by quotes. Examples of this are `'self'`, `'none'` and `'unsafe-inline'`. When using `addDirective` function you're not required to surround the directive value with quotes manually. We will automatically add quotes. Script/style hashes, as well, will be auto-detected and surrounded with quotes.
 
 ```php
 // in a policy
 ...
    ->addDirective(Directive::SCRIPT, Value::SELF) // will output `'self'` when outputting headers
+   ->addDirective(Directive::STYLE, 'sha256-hash') // will output `'sha256-hash'` when outputting headers
 ...
 ```
 
-You can add multiple policy options in the same directive giving an array as second parameter to `addDirective`.
+You can add multiple policy options in the same directive giving an array as second parameter to `addDirective` or a single string in which every option is separated by one or more spaces.
 
 ```php
 // in a policy
 ...
    ->addDirective(Directive::SCRIPT, [
+       Value::STRICT_DYNAMIC,
        Value::SELF,
        'www.google.com',
    ])
-   // will output `'self' www.google.com` when outputting headers
+   ->addDirective(Directive::SCRIPT, 'strict-dynamic self  www.google.com')
+   // will both output `'strict_dynamic' 'self' www.google.com` when outputting headers
 ...
 ```
 

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -29,9 +29,7 @@ abstract class Policy
         $this->guardAgainstInvalidDirectives($directive);
 
         $rules = array_flatten(array_map(function ($values) {
-            return array_filter(explode(' ', $values), function ($value) {
-                return ! empty($value);
-            });
+            return array_filter(explode(' ', $values));
         }, array_wrap($values)));
 
         foreach ($rules as $rule) {

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -29,7 +29,9 @@ abstract class Policy
         $this->guardAgainstInvalidDirectives($directive);
 
         $rules = array_flatten(array_map(function ($values) {
-            return explode(' ', $values);
+            return array_filter(explode(' ', $values), function ($value) {
+                return !empty($value);
+            });
         }, array_wrap($values)));
 
         foreach ($rules as $rule) {

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -112,15 +112,15 @@ abstract class Policy
     protected function isHash(string $value): bool
     {
         $acceptableHashingAlgorithms = [
-          'sha256',
-          'sha384',
-          'sha512',
+          'sha256-',
+          'sha384-',
+          'sha512-',
         ];
 
-        return in_array(explode('-', $value)[0], $acceptableHashingAlgorithms);
+        return starts_with($value, $acceptableHashingAlgorithms);
     }
 
-    protected function sanitizeValue(string $value): string
+    protected function isSpecialDirective(string $value): bool
     {
         $specialDirectiveValues = [
             Value::NONE,
@@ -131,7 +131,12 @@ abstract class Policy
             Value::UNSAFE_INLINE,
         ];
 
-        if (in_array($value, $specialDirectiveValues) || $this->isHash($value)) {
+        return in_array($value, $specialDirectiveValues);
+    }
+
+    protected function sanitizeValue(string $value): string
+    {
+        if ($this->isSpecialDirective($value) || $this->isHash($value)) {
             return "'{$value}'";
         }
 

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -30,7 +30,7 @@ abstract class Policy
 
         $rules = array_flatten(array_map(function ($values) {
             return array_filter(explode(' ', $values), function ($value) {
-                return !empty($value);
+                return ! empty($value);
             });
         }, array_wrap($values)));
 

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -175,6 +175,50 @@ class GlobalMiddlewareTest extends TestCase
     }
 
     /** @test */
+    public function it_will_automatically_quote_hashed_value()
+    {
+        $policy = new class extends Policy {
+            public function configure()
+            {
+                $this->addDirective(Directive::SCRIPT, [
+                    'sha256-hash1',
+                    'sha384-hash2',
+                    'sha512-hash3',
+                ]);
+            }
+        };
+
+        config(['csp.policy' => get_class($policy)]);
+
+        $headers = $this->getResponseHeaders();
+
+        $this->assertEquals(
+            "script-src 'sha256-hash1' 'sha384-hash2' 'sha512-hash3'",
+            $headers->get('Content-Security-Policy')
+        );
+    }
+
+    /** @test */
+    public function it_will_automatically_quote_special_and_hashed_values_when_given_in_a_single_string()
+    {
+        $policy = new class extends Policy {
+            public function configure()
+            {
+                $this->addDirective(Directive::SCRIPT, 'sha256-hash1 ' . Value::SELF);
+            }
+        };
+
+        config(['csp.policy' => get_class($policy)]);
+
+        $headers = $this->getResponseHeaders();
+
+        $this->assertEquals(
+            "script-src 'sha256-hash1' 'self'",
+            $headers->get('Content-Security-Policy')
+        );
+    }
+
+    /** @test */
     public function it_will_not_output_the_same_directive_values_twice()
     {
         $policy = new class extends Policy {

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -175,7 +175,7 @@ class GlobalMiddlewareTest extends TestCase
     }
 
     /** @test */
-    public function it_will_automatically_quote_hashed_value()
+    public function it_will_automatically_quote_hashed_values()
     {
         $policy = new class extends Policy {
             public function configure()

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -205,7 +205,7 @@ class GlobalMiddlewareTest extends TestCase
             public function configure()
             {
                 $this->addDirective(Directive::SCRIPT,
-                    'sha256-hash1 ' . Value::SELF . '  source');
+                    'sha256-hash1 '.Value::SELF.'  source');
             }
         };
 

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -199,12 +199,13 @@ class GlobalMiddlewareTest extends TestCase
     }
 
     /** @test */
-    public function it_will_automatically_quote_special_and_hashed_values_when_given_in_a_single_string()
+    public function it_will_atomically_check_values_when_they_are_given_in_a_single_string_separated_by_spaces()
     {
         $policy = new class extends Policy {
             public function configure()
             {
-                $this->addDirective(Directive::SCRIPT, 'sha256-hash1 ' . Value::SELF);
+                $this->addDirective(Directive::SCRIPT,
+                    'sha256-hash1 ' . Value::SELF . '  source');
             }
         };
 
@@ -213,7 +214,7 @@ class GlobalMiddlewareTest extends TestCase
         $headers = $this->getResponseHeaders();
 
         $this->assertEquals(
-            "script-src 'sha256-hash1' 'self'",
+            "script-src 'sha256-hash1' 'self' source",
             $headers->get('Content-Security-Policy')
         );
     }


### PR DESCRIPTION
#33 

As described in the title **PLUS** the fact that now it's possible to give multiple options separated by one or more spaces and they'll still be examined atomically, which came natural to me to prevent possible errors with hash detection: the string `sha256-hash some random text` would have been all enclosed in a single couple of quotes without this feature.

It can be easily removed if that feature isn't welcome, even if I think it can help to provide more flexibility and usability.