### PR TITLE
FIX: blade compiler does not call csp_nonce() in @nonce directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 build
 composer.lock
 docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 build
 composer.lock
 docs

--- a/src/CspServiceProvider.php
+++ b/src/CspServiceProvider.php
@@ -23,7 +23,7 @@ class CspServiceProvider extends ServiceProvider
         });
 
         Blade::directive('nonce', function () {
-            return "<?php echo \"nonce='csp_nonce()'\"; ?>";
+            return '<?php echo "nonce=\"" . csp_nonce() . "\""; ?>';
         });
     }
 

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\Csp\Tests;
+
+class BladeTest extends TestCase
+{
+    /** @test */
+    public function blade_directive_outputs_correct_nonce()
+    {
+        // make sure view is compiled fresh each run
+        $this->artisan('view:clear');
+
+        $nonce = csp_nonce();
+
+        $view = app('view')
+            ->file(__DIR__. '/fixtures/view.blade.php')
+            ->render();
+
+        $this->assertEquals('<script nonce="' . $nonce . '"></script>', $view);
+    }
+}

--- a/tests/BladeTest.php
+++ b/tests/BladeTest.php
@@ -13,9 +13,9 @@ class BladeTest extends TestCase
         $nonce = csp_nonce();
 
         $view = app('view')
-            ->file(__DIR__. '/fixtures/view.blade.php')
+            ->file(__DIR__.'/fixtures/view.blade.php')
             ->render();
 
-        $this->assertEquals('<script nonce="' . $nonce . '"></script>', $view);
+        $this->assertEquals('<script nonce="'.$nonce.'"></script>', $view);
     }
 }

--- a/tests/fixtures/view.blade.php
+++ b/tests/fixtures/view.blade.php
@@ -1,0 +1,1 @@
+<script @nonce></script>


### PR DESCRIPTION
`@nonce` blade directive inlines `csp_nonce()` call inside string and blade compiler does not call the function.
Resulting compiled output is `nonce='csp_nonce()'`

Changed directive to so that the function call is explicit.