### PR TITLE
Add value constant for “data:”

### DIFF
--- a/src/Value.php
+++ b/src/Value.php
@@ -4,6 +4,7 @@ namespace Spatie\Csp;
 
 abstract class Value
 {
+    const DATA = 'data:';
     const NONE = 'none';
     const REPORT_SAMPLE = 'report-sample';
     const SELF = 'self';


### PR DESCRIPTION
I've simply added a new vale constant for "data:" which allows the loading of resources via the data scheme (eg Base64 encoded images).

It came about because the [barryvdh/laravel-debugbar](https://github.com/barryvdh/laravel-debugbar) package uses base64 encoded images for it's icons.

This is my first pull request, so if I've missed anything, please let me know! 