### PR TITLE
Add scheme values

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ According to the spec certain directive values need to be surrounded by quotes. 
 ```php
 // in a policy
 ...
-   ->addDirective(Directive::SCRIPT, Value::SELF) // will output `'self'` when outputting headers
+   ->addDirective(Directive::SCRIPT, Keyword::SELF) // will output `'self'` when outputting headers
    ->addDirective(Directive::STYLE, 'sha256-hash') // will output `'sha256-hash'` when outputting headers
 ...
 ```
@@ -120,8 +120,8 @@ You can add multiple policy options in the same directive giving an array as sec
 // in a policy
 ...
    ->addDirective(Directive::SCRIPT, [
-       Value::STRICT_DYNAMIC,
-       Value::SELF,
+       Keyword::STRICT_DYNAMIC,
+       Keyword::SELF,
        'www.google.com',
    ])
    ->addDirective(Directive::SCRIPT, 'strict-dynamic self  www.google.com')
@@ -160,15 +160,15 @@ class Basic extends Policy
     public function configure()
     {
         $this
-            ->addDirective(Directive::BASE, Value::SELF)
-            ->addDirective(Directive::CONNECT, Value::SELF)
-            ->addDirective(Directive::DEFAULT, Value::SELF)
-            ->addDirective(Directive::FORM_ACTION, Value::SELF)
-            ->addDirective(Directive::IMG, Value::SELF)
-            ->addDirective(Directive::MEDIA, Value::SELF)
-            ->addDirective(Directive::OBJECT, Value::NONE)
-            ->addDirective(Directive::SCRIPT, Value::SELF)
-            ->addDirective(Directive::STYLE, Value::SELF)
+            ->addDirective(Directive::BASE, Keyword::SELF)
+            ->addDirective(Directive::CONNECT, Keyword::SELF)
+            ->addDirective(Directive::DEFAULT, Keyword::SELF)
+            ->addDirective(Directive::FORM_ACTION, Keyword::SELF)
+            ->addDirective(Directive::IMG, Keyword::SELF)
+            ->addDirective(Directive::MEDIA, Keyword::SELF)
+            ->addDirective(Directive::OBJECT, Keyword::NONE)
+            ->addDirective(Directive::SCRIPT, Keyword::SELF)
+            ->addDirective(Directive::STYLE, Keyword::SELF)
             ->addNonceForDirective(Directive::SCRIPT)
             ->addNonceForDirective(Directive::STYLE);
     }

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "illuminate/support": "~5.5.0|~5.6.0|~5.7.0"
     },
     "require-dev": {
+        "mockery/mockery": "^1.0",
         "orchestra/testbench": "~3.5|~3.6|~3.7",
         "phpunit/phpunit": "^6.5|^7.0"
     },

--- a/src/Keyword.php
+++ b/src/Keyword.php
@@ -5,7 +5,6 @@ namespace Spatie\Csp;
 abstract class Keyword
 {
     const NONE = 'none';
-    const NO_VALUE = false;
     const REPORT_SAMPLE = 'report-sample';
     const SELF = 'self';
     const STRICT_DYNAMIC = 'strict-dynamic';

--- a/src/Keyword.php
+++ b/src/Keyword.php
@@ -2,9 +2,8 @@
 
 namespace Spatie\Csp;
 
-abstract class Value
+abstract class Keyword
 {
-    const DATA = 'data:';
     const NONE = 'none';
     const REPORT_SAMPLE = 'report-sample';
     const SELF = 'self';

--- a/src/Policies/Basic.php
+++ b/src/Policies/Basic.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\Csp\Policies;
 
-use Spatie\Csp\Value;
+use Spatie\Csp\Keyword;
 use Spatie\Csp\Directive;
 
 class Basic extends Policy
@@ -10,15 +10,15 @@ class Basic extends Policy
     public function configure()
     {
         $this
-            ->addDirective(Directive::BASE, Value::SELF)
-            ->addDirective(Directive::CONNECT, Value::SELF)
-            ->addDirective(Directive::DEFAULT, Value::SELF)
-            ->addDirective(Directive::FORM_ACTION, Value::SELF)
-            ->addDirective(Directive::IMG, Value::SELF)
-            ->addDirective(Directive::MEDIA, Value::SELF)
-            ->addDirective(Directive::OBJECT, Value::NONE)
-            ->addDirective(Directive::SCRIPT, Value::SELF)
-            ->addDirective(Directive::STYLE, Value::SELF)
+            ->addDirective(Directive::BASE, Keyword::SELF)
+            ->addDirective(Directive::CONNECT, Keyword::SELF)
+            ->addDirective(Directive::DEFAULT, Keyword::SELF)
+            ->addDirective(Directive::FORM_ACTION, Keyword::SELF)
+            ->addDirective(Directive::IMG, Keyword::SELF)
+            ->addDirective(Directive::MEDIA, Keyword::SELF)
+            ->addDirective(Directive::OBJECT, Keyword::NONE)
+            ->addDirective(Directive::SCRIPT, Keyword::SELF)
+            ->addDirective(Directive::STYLE, Keyword::SELF)
             ->addNonceForDirective(Directive::SCRIPT)
             ->addNonceForDirective(Directive::STYLE);
     }

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -2,7 +2,8 @@
 
 namespace Spatie\Csp\Policies;
 
-use Spatie\Csp\Value;
+use ReflectionClass;
+use Spatie\Csp\Keyword;
 use Spatie\Csp\Directive;
 use Illuminate\Http\Request;
 use Spatie\Csp\Exceptions\InvalidDirective;
@@ -118,23 +119,19 @@ abstract class Policy
         return starts_with($value, $acceptableHashingAlgorithms);
     }
 
-    protected function isSpecialDirective(string $value): bool
+    protected function isKeyword(string $value): bool
     {
-        $specialDirectiveValues = [
-            Value::NONE,
-            Value::REPORT_SAMPLE,
-            Value::SELF,
-            Value::STRICT_DYNAMIC,
-            Value::UNSAFE_EVAL,
-            Value::UNSAFE_INLINE,
-        ];
+        $specialDirectiveValues = (new ReflectionClass(Keyword::class))->getConstants();
 
         return in_array($value, $specialDirectiveValues);
     }
 
     protected function sanitizeValue(string $value): string
     {
-        if ($this->isSpecialDirective($value) || $this->isHash($value)) {
+        if (
+            $this->isKeyword($value)
+            || $this->isHash($value)
+        ) {
             return "'{$value}'";
         }
 

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -7,6 +7,7 @@ use Spatie\Csp\Keyword;
 use Spatie\Csp\Directive;
 use Illuminate\Http\Request;
 use Spatie\Csp\Exceptions\InvalidDirective;
+use Spatie\Csp\Value;
 use Symfony\Component\HttpFoundation\Response;
 
 abstract class Policy
@@ -29,12 +30,18 @@ abstract class Policy
     {
         $this->guardAgainstInvalidDirectives($directive);
 
-        $rules = array_flatten(array_map(function ($values) {
-            return empty($values) ? $values : array_filter(explode(' ', $values));
-        }, array_wrap($values)));
+        if ($values === Value::NO_VALUE) {
+            $this->directives[$directive][] = Value::NO_VALUE;
 
-        foreach ($rules as $rule) {
-            $sanitizedValue = $this->sanitizeValue($rule);
+            return $this;
+        }
+
+        $values = array_filter(array_flatten(array_map(function ($value) {
+            return explode(' ', $value);
+        }, array_wrap($values))));
+
+        foreach ($values as $value) {
+            $sanitizedValue = $this->sanitizeValue($value);
 
             if (! in_array($sanitizedValue, $this->directives[$directive] ?? [])) {
                 $this->directives[$directive][] = $sanitizedValue;

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -3,11 +3,11 @@
 namespace Spatie\Csp\Policies;
 
 use ReflectionClass;
+use Spatie\Csp\Value;
 use Spatie\Csp\Keyword;
 use Spatie\Csp\Directive;
 use Illuminate\Http\Request;
 use Spatie\Csp\Exceptions\InvalidDirective;
-use Spatie\Csp\Value;
 use Symfony\Component\HttpFoundation\Response;
 
 abstract class Policy

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -19,7 +19,7 @@ abstract class Policy
 
     /**
      * @param string $directive
-     * @param string|array $values
+     * @param string|array|bool $values
      *
      * @return \Spatie\Csp\Policies\Policy
      *

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -121,9 +121,9 @@ abstract class Policy
 
     protected function isKeyword(string $value): bool
     {
-        $specialDirectiveValues = (new ReflectionClass(Keyword::class))->getConstants();
+        $keywords = (new ReflectionClass(Keyword::class))->getConstants();
 
-        return in_array($value, $specialDirectiveValues);
+        return in_array($value, $keywords);
     }
 
     protected function sanitizeValue(string $value): string

--- a/src/Scheme.php
+++ b/src/Scheme.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\Csp;
+
+abstract class Scheme
+{
+    const DATA = 'data:';
+    const HTTP = 'http:';
+    const HTTPS = 'https:';
+    const BLOB = 'blob:';
+}

--- a/src/Value.php
+++ b/src/Value.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\Csp;
+
+abstract class Value
+{
+    const NO_VALUE = false;
+}

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Csp\Tests;
 
+use Spatie\Csp\Scheme;
 use Spatie\Csp\Keyword;
 use Spatie\Csp\Directive;
 use Spatie\Csp\AddCspHeaders;
@@ -10,7 +11,6 @@ use Spatie\Csp\Policies\Policy;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Route;
 use Spatie\Csp\Exceptions\InvalidCspPolicy;
-use Spatie\Csp\Scheme;
 use Symfony\Component\HttpFoundation\HeaderBag;
 
 class GlobalMiddlewareTest extends TestCase
@@ -282,7 +282,7 @@ class GlobalMiddlewareTest extends TestCase
         $headers = $this->getResponseHeaders();
 
         $this->assertEquals(
-            "img-src data: https:",
+            'img-src data: https:',
             $headers->get('Content-Security-Policy')
         );
     }

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -10,6 +10,7 @@ use Spatie\Csp\Policies\Policy;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Route;
 use Spatie\Csp\Exceptions\InvalidCspPolicy;
+use Spatie\Csp\Scheme;
 use Symfony\Component\HttpFoundation\HeaderBag;
 
 class GlobalMiddlewareTest extends TestCase
@@ -259,6 +260,29 @@ class GlobalMiddlewareTest extends TestCase
 
         $this->assertEquals(
             'base-uri custom-policy',
+            $headers->get('Content-Security-Policy')
+        );
+    }
+
+    /** @test */
+    public function it_will_handle_scheme_values()
+    {
+        $policy = new class extends Policy {
+            public function configure()
+            {
+                $this->addDirective(Directive::IMG, [
+                    Scheme::DATA,
+                    Scheme::HTTPS,
+                ]);
+            }
+        };
+
+        config(['csp.policy' => get_class($policy)]);
+
+        $headers = $this->getResponseHeaders();
+
+        $this->assertEquals(
+            "img-src data: https:",
             $headers->get('Content-Security-Policy')
         );
     }

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\Csp\Tests;
 
-use Spatie\Csp\Value;
+use Spatie\Csp\Keyword;
 use Spatie\Csp\Directive;
 use Spatie\Csp\AddCspHeaders;
 use Spatie\Csp\Policies\Basic;
@@ -160,7 +160,7 @@ class GlobalMiddlewareTest extends TestCase
         $policy = new class extends Policy {
             public function configure()
             {
-                $this->addDirective(Directive::SCRIPT, [Value::SELF]);
+                $this->addDirective(Directive::SCRIPT, [Keyword::SELF]);
             }
         };
 
@@ -205,7 +205,7 @@ class GlobalMiddlewareTest extends TestCase
             public function configure()
             {
                 $this->addDirective(Directive::SCRIPT,
-                    'sha256-hash1 '.Value::SELF.'  source');
+                    'sha256-hash1 '.Keyword::SELF.'  source');
             }
         };
 
@@ -225,7 +225,7 @@ class GlobalMiddlewareTest extends TestCase
         $policy = new class extends Policy {
             public function configure()
             {
-                $this->addDirective(Directive::SCRIPT, [Value::SELF, Value::SELF]);
+                $this->addDirective(Directive::SCRIPT, [Keyword::SELF, Keyword::SELF]);
             }
         };
 

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -11,6 +11,7 @@ use Spatie\Csp\Policies\Policy;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Route;
 use Spatie\Csp\Exceptions\InvalidCspPolicy;
+use Spatie\Csp\Value;
 use Symfony\Component\HttpFoundation\HeaderBag;
 
 class GlobalMiddlewareTest extends TestCase

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Csp\Tests;
 
+use Spatie\Csp\Value;
 use Spatie\Csp\Scheme;
 use Spatie\Csp\Keyword;
 use Spatie\Csp\Directive;
@@ -11,7 +12,6 @@ use Spatie\Csp\Policies\Policy;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Route;
 use Spatie\Csp\Exceptions\InvalidCspPolicy;
-use Spatie\Csp\Value;
 use Symfony\Component\HttpFoundation\HeaderBag;
 
 class GlobalMiddlewareTest extends TestCase


### PR DESCRIPTION
**breaking**

This adds also `blob`, `http/s` scheme in addition to #38 

The renaming of the `Value` class and the move of the `data` constant are the breaking changes. I'm open for discussions and can also send a PR that adds these constants to the `Value` class to keep this open for `v2`.