### PR TITLE
Add lumen compatibility (by not using the facades)

### DIFF
--- a/src/CspServiceProvider.php
+++ b/src/CspServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Spatie\Csp;
 
 use Spatie\Csp\Nonce\NonceGenerator;
-use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 
 class CspServiceProvider extends ServiceProvider
@@ -22,7 +21,7 @@ class CspServiceProvider extends ServiceProvider
             return app(NonceGenerator::class)->generate();
         });
 
-        Blade::directive('nonce', function () {
+        $this->app->view->getEngineResolver()->resolve('blade')->getCompiler()->directive('nonce', function () {
             return '<?php echo "nonce=\"" . csp_nonce() . "\""; ?>';
         });
     }


### PR DESCRIPTION
By default facades are not enabled on Lumen. We can easily do without it to ensure compatibility.