### PR TITLE
Fix lumen compatibility in console

### DIFF
--- a/src/CspServiceProvider.php
+++ b/src/CspServiceProvider.php
@@ -10,7 +10,7 @@ class CspServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        if ($this->app->runningInConsole()) {
+        if ($this->app->runningInConsole() && function_exists('config_path')) {
             $this->publishes([
                 __DIR__.'/../config/csp.php' => config_path('csp.php'),
             ], 'config');


### PR DESCRIPTION
The config_path method does not exist on lumen by default (we need to manually configure the configs with a method of our choice).