### PR TITLE
Change Value::NO_VALUE to empty string

### DIFF
--- a/src/Value.php
+++ b/src/Value.php
@@ -6,7 +6,7 @@ abstract class Value
 {
     const DATA = 'data:';
     const NONE = 'none';
-    const NO_VALUE = false;
+    const NO_VALUE = '';
     const REPORT_SAMPLE = 'report-sample';
     const SELF = 'self';
     const STRICT_DYNAMIC = 'strict-dynamic';


### PR DESCRIPTION
[Phan](https://github.com/phan/phan) complains about Value::NO_VALUE not being an array or a string as required by addDirective's Docblock:
```
PhanTypeMismatchArgument Argument 2 (values) is false but \Spatie\Csp\Policies\Policy::addDirective() takes array|string defined at vendor/spatie/laravel-csp/src/Policies/Policy.php:27
```
So I've changed Value::NO_VALUE to an empty string. An alternative solution would be to allow bools in the Docblock.