### PR TITLE
Helper shortcut: csp_attr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,19 @@ Next you must add the nonce to the html:
 </script>
 ```
 
+or:
+
+```
+{{-- in a view --}}
+<style {{ csp_attr() }}">
+   ...
+</style>
+
+<script {{ csp_attr() }}">
+   ...
+</script>
+```
+
 There are few other options to use inline styles and scripts. Take a look at the [CSP docs on the Mozilla developer site](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src) to know more.
 
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -6,3 +6,13 @@ if (! function_exists('csp_nonce')) {
         return app('csp-nonce');
     }
 }
+
+
+if (! function_exists('csp_attr')) {
+    function csp_attr(): \Illuminate\Support\HtmlString
+    {
+            $nonce = csp_nonce();
+            return new \Illuminate\Support\HtmlString(sprintf('nonce="%s"', e($nonce)));
+
+    }
+}


### PR DESCRIPTION
This commit adds a `csp_attr` function that will prefix the csp with the proper html attribute, mainly so it looks nicer in blade views.