### PR TITLE
Added "report-to" directive

### DIFF
--- a/src/Directive.php
+++ b/src/Directive.php
@@ -21,6 +21,7 @@ abstract class Directive
     const OBJECT = 'object-src';
     const PLUGIN = 'plugin-types';
     const REPORT = 'report-uri';
+    const REPORT_TO = 'report-to';
     const SANDBOX = 'sandbox';
     const SCRIPT = 'script-src';
     const SCRIPT_ATTR = 'script-src-attr';


### PR DESCRIPTION
Report-to supersedes report-uri, although it is only currently supported in Chrome (and Chrome-based Edge). It would be nice to have access to both.