### PR TITLE
add prefetch-src directive

### DIFF
--- a/src/Directive.php
+++ b/src/Directive.php
@@ -20,6 +20,7 @@ abstract class Directive
     const MEDIA = 'media-src';
     const OBJECT = 'object-src';
     const PLUGIN = 'plugin-types';
+    const PREFETCH = 'prefetch-src';
     const REPORT = 'report-uri';
     const REPORT_TO = 'report-to';
     const SANDBOX = 'sandbox';


### PR DESCRIPTION
This PR adds the directive for `prefetch-src`, which was uncovered while integrating with plaid that uses this directive. 

> link-initialize.js:1 Refused to prefetch content from 'https://cdn.plaid.com/link/2.0.735/link-dynamic-loader.js' because it violates the following Content Security Policy directive: "default-src 'self'". Note that 'prefetch-src' was not explicitly set, so 'default-src' is used as a fallback.