### PR TITLE
Make package compatible with php-cs-fixer v3

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -15,7 +15,7 @@ jobs:
             -   name: Run PHP CS Fixer
                 uses: docker://oskarstark/php-cs-fixer-ga
                 with:
-                    args: --config=.php_cs.dist --allow-risky=yes
+                    args: --config=.php-cs-fixer.dist.php --allow-risky=yes
 
             -   name: Commit changes
                 uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,7 +34,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php }}
-                    extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+                    extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
                     coverage: none
 
             -   name: Install dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,17 +10,13 @@ jobs:
             matrix:
                 os: [ubuntu-latest, windows-latest]
                 php: [8.0, 7.4]
-                laravel: [8.*, 5.8.*, 6.*, 7.*]
+                laravel: [6.*, 8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 8.*
                         testbench: 6.*
-                    -   laravel: 7.*
-                        testbench: 5.*
                     -   laravel: 6.*
                         testbench: 4.*
-                    -   laravel: 5.8.*
-                        testbench: 3.8.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ composer.lock
 docs
 vendor
 coverage
-.php_cs.cache
+.php-cs-fixer.cache
+.phpunit.result.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,6 +1,6 @@
 <?php
 
-$finder = Symfony\Component\Finder\Finder::create()
+$finder = PhpCsFixer\Finder::create()
     ->notPath('bootstrap/*')
     ->notPath('storage/*')
     ->notPath('resources/view/mail/*')
@@ -13,14 +13,13 @@ $finder = Symfony\Component\Finder\Finder::create()
     ->ignoreDotFiles(true)
     ->ignoreVCS(true);
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR2' => true,
-        'array_syntax' => ['syntax' => 'short'],
-        'ordered_imports' => ['sortAlgorithm' => 'alpha'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'no_unused_imports' => true,
         'not_operator_with_successor_space' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline' => true,
         'phpdoc_scalar' => true,
         'unary_operator_spaces' => true,
         'binary_operator_spaces' => true,
@@ -32,6 +31,6 @@ return PhpCsFixer\Config::create()
         'method_argument_space' => [
             'on_multiline' => 'ensure_fully_multiline',
             'keep_multiple_spaces_after_comma' => true,
-        ]
+        ],
     ])
     ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,11 @@
         "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "roave/security-advisories": "dev-master",
+        "friendsofphp/php-cs-fixer": "^3.2",
         "mockery/mockery": "^1.0|^1.3.1",
         "orchestra/testbench": "~3.8.0|^4.0|^5.0|^6.0",
-        "phpunit/phpunit": "^8.0|^9.3"
+        "phpunit/phpunit": "^8.0|^9.3",
+        "roave/security-advisories": "dev-master"
     },
     "autoload": {
         "psr-4": {
@@ -53,6 +54,7 @@
         }
     },
     "scripts": {
+        "lint": "php-cs-fixer fix",
         "test": "vendor/bin/phpunit",
         "test-coverage": "phpunit --coverage-html coverage"
     },

--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,9 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.2",
-        "mockery/mockery": "^1.0|^1.3.1",
+        "mockery/mockery": "^1.3.3",
         "orchestra/testbench": "^4.0|^6.0",
-        "phpunit/phpunit": "^8.0|^9.3",
+        "phpunit/phpunit": "^9.3",
         "roave/security-advisories": "dev-master"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -30,13 +30,13 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.2|^8.0",
-        "illuminate/http": "~5.8.0|^6.0|^7.0|^8.0",
-        "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0"
+        "illuminate/http": "^6.0|^8.0",
+        "illuminate/support": "^6.0|^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.2",
         "mockery/mockery": "^1.0|^1.3.1",
-        "orchestra/testbench": "~3.8.0|^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^4.0|^6.0",
         "phpunit/phpunit": "^8.0|^9.3",
         "roave/security-advisories": "dev-master"
     },


### PR DESCRIPTION
This fixes errors in GitHub actions, see https://github.com/spatie/laravel-csp/runs/3734009499 for example.

Details: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/UPGRADE-v3.md

### Also

* removed unsupported/outdated Laravel 5.8 and 7 version from test-matrix (`roave/security-advisories` complained about those)
* removed support for PHPUnit v8, since it is not compatible with the current phpunit XML-config
* added `fileinfo` PHP extension to fix errors on `windows-latest`