### PR TITLE
Lazily register blade directives

### DIFF
--- a/src/CspServiceProvider.php
+++ b/src/CspServiceProvider.php
@@ -23,7 +23,9 @@ class CspServiceProvider extends PackageServiceProvider
             return app(NonceGenerator::class)->generate();
         });
 
-        $this->registerBladeDirectives();
+        $this->callAfterResolving('view', function () {
+            $this->registerBladeDirectives();
+        });
     }
 
     private function registerBladeDirectives(): void


### PR DESCRIPTION
Right now this package always boots up Blade in order to register its directives, even if the app itself might not need blade to handle whatever its doing. This PR changes the bootstrapping process to wait for blade to be resolved before registering the directives. If blade was previously resolved (by another service provider or a piece of app code) the directives will be registered immediately