### PR TITLE
Add wss: (secure websocket) scheme support

### DIFF
--- a/src/Scheme.php
+++ b/src/Scheme.php
@@ -4,9 +4,10 @@ namespace Spatie\Csp;
 
 abstract class Scheme
 {
+    const BLOB = 'blob:';
     const DATA = 'data:';
     const HTTP = 'http:';
     const HTTPS = 'https:';
-    const BLOB = 'blob:';
     const WS = 'ws:';
+    const WSS = 'wss:';
 }

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -305,6 +305,7 @@ it('will handle scheme values', function (): void {
                 Scheme::DATA,
                 Scheme::HTTPS,
                 Scheme::WS,
+                Scheme::WSS,
             ]);
         }
     };
@@ -314,7 +315,7 @@ it('will handle scheme values', function (): void {
     $headers = getResponseHeaders();
 
     assertEquals(
-        'img-src data: https: ws:',
+        'img-src data: https: ws: wss:',
         $headers->get('Content-Security-Policy')
     );
 });


### PR DESCRIPTION
Adds an extra constant `WSS` to the `Scheme` enum class to support the secure websocket protocol

I also sorted the constants in that class alphabetically to match the other classes.