### PR TITLE
Add require-trusted-types-for directive

### DIFF
--- a/src/Directive.php
+++ b/src/Directive.php
@@ -23,6 +23,7 @@ abstract class Directive
     const PREFETCH = 'prefetch-src';
     const REPORT = 'report-uri';
     const REPORT_TO = 'report-to';
+    const REQUIRE_TRUSTED_TYPES_FOR = 'require-trusted-types-for';
     const SANDBOX = 'sandbox';
     const SCRIPT = 'script-src';
     const SCRIPT_ATTR = 'script-src-attr';


### PR DESCRIPTION
This pull request adds support for the `require-trusted-types-for` directive.

The directive is documented as follows: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for 
Browser support list: https://caniuse.com/mdn-http_headers_content-security-policy_require-trusted-types-for