### PR TITLE
feat: added missing 'wasm-unsafe-eval' keyword

### DIFF
--- a/src/Keyword.php
+++ b/src/Keyword.php
@@ -11,4 +11,5 @@ abstract class Keyword
     const UNSAFE_EVAL = 'unsafe-eval';
     const UNSAFE_HASHES = 'unsafe-hashes';
     const UNSAFE_INLINE = 'unsafe-inline';
+    const UNSAFE_WEB_ASSEMBLY_EXECUTION = 'wasm-unsafe-eval';
 }


### PR DESCRIPTION
This pull request adds the missing Content Security Policy (CSP) keyword wasm-unsafe-eval.

`Content-Security-Policy: script-src 'wasm-unsafe-eval'`

[MDN WEb Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_webassembly_execution)