### PR TITLE
Mark arguments as nullable in AddCspHeaders

### DIFF
--- a/src/AddCspHeaders.php
+++ b/src/AddCspHeaders.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Collection;
 
 class AddCspHeaders
 {
-    public function handle(Request $request, Closure $next, string $customPolicyClass = null)
+    public function handle(Request $request, Closure $next, ?string $customPolicyClass = null)
     {
         $response = $next($request);
 
@@ -20,7 +20,7 @@ class AddCspHeaders
         return $response;
     }
 
-    protected function getPolicies(string $customPolicyClass = null): Collection
+    protected function getPolicies(?string $customPolicyClass = null): Collection
     {
         $policies = collect();
 


### PR DESCRIPTION
This is #107 renewed now that PHP 8.4 will deprecate the old behavior; see also [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated).