### PR TITLE
chore: update Git Attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,10 +2,12 @@
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
 # Ignore all test and documentation with "export-ignore".
-/.gitattributes     export-ignore
-/.gitignore         export-ignore
-/.travis.yml        export-ignore
-/phpunit.xml.dist   export-ignore
-/.scrutinizer.yml   export-ignore
-/tests              export-ignore
-/.editorconfig      export-ignore
+/.gitattributes          export-ignore
+/.github                 export-ignore
+/.gitignore              export-ignore
+/.php-cs-fixer.dist.php  export-ignore
+/.travis.yml             export-ignore
+/phpunit.xml.dist        export-ignore
+/.scrutinizer.yml        export-ignore
+/tests                   export-ignore
+/.editorconfig           export-ignore


### PR DESCRIPTION
This ensures that the `.github` directory and `.php-cs-fixer.dist.php` file is not included in vendor releases.