### PR TITLE
Add ability to skip nonce generation

### DIFF
--- a/config/csp.php
+++ b/config/csp.php
@@ -31,4 +31,12 @@ return [
      * The class responsible for generating the nonces used in inline tags and headers.
      */
     'nonce_generator' => Spatie\Csp\Nonce\RandomString::class,
+
+    /*
+     * Set to false to disable automatic nonce generation and handling.
+     * This is useful when you want to use 'unsafe-inline' for scripts/styles
+     * and cannot add inline nonces. 
+     * Note that this will make your CSP policy less secure.
+     */
+    'nonce_enabled' => env('CSP_NONCE_ENABLED', true),
 ];

--- a/src/CspServiceProvider.php
+++ b/src/CspServiceProvider.php
@@ -17,11 +17,13 @@ class CspServiceProvider extends PackageServiceProvider
 
     public function packageBooted()
     {
-        $this->app->singleton(NonceGenerator::class, config('csp.nonce_generator'));
-
-        $this->app->singleton('csp-nonce', function () {
-            return app(NonceGenerator::class)->generate();
-        });
+        if (config('csp.nonce_enabled', true)) {
+            $this->app->singleton(NonceGenerator::class, config('csp.nonce_generator'));
+            
+            $this->app->singleton('csp-nonce', function () {
+                return app(NonceGenerator::class)->generate();
+            });
+        }
 
         $this->callAfterResolving('view', function () {
             $this->registerBladeDirectives();

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -87,7 +87,16 @@ abstract class Policy
 
     public function addNonceForDirective(string $directive): self
     {
-        return $this->addDirective($directive, "'nonce-".app('csp-nonce')."'");
+        if (!config('csp.nonce_enabled', true)) {
+            return $this;
+        }
+
+        $nonce = app('csp-nonce');
+        if (empty($nonce)) {
+            return $this;
+        }
+
+        return $this->addDirective($directive, "'nonce-{$nonce}'");
     }
 
     public function prepareHeader(): string


### PR DESCRIPTION
This PR adds the ability to skip nonce generation when using unsafe-inline in your CSP policy. This is implemented by:

- Adding `nonce_enabled` config option (defaults to true)
- Updating Policy class to skip adding nonces when disabled
- Adding documentation about use cases and security implications

This is particularly useful when:
- Using unsafe-inline for legacy code compatibility 
- Working with third-party scripts that don't support nonces
- Debugging CSP issues

Note: Disabling nonces in favor of unsafe-inline reduces security. Only use when necessary.