### PR TITLE
Add support for Laravel 12

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,16 +12,6 @@ jobs:
                 php: [8.4, 8.3, 8.2, 8.1]
                 laravel: [^12, ^11.36.1, 10.*, 9.*]
                 dependency-version: [prefer-lowest, prefer-stable]
-                include:
-                    -   laravel: ^11.36.1
-                        testbench: ^9.9
-                        carbon: ^3.0
-                    -   laravel: 10.*
-                        testbench: 8.*
-                        carbon: ^2.63
-                    -   laravel: 9.*
-                        testbench: 7.*
-                        carbon: ^2.63
                 exclude:
                     -   laravel: ^11.36.1
                         php: 8.1
@@ -47,7 +37,7 @@ jobs:
 
             -   name: Install dependencies
                 run: |
-                    composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:${{ matrix.carbon }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                    composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
             -   name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 php: [8.4, 8.3, 8.2, 8.1]
-                laravel: [^11.36.1, 10.*, 9.*]
+                laravel: [^12, ^11.36.1, 10.*, 9.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: ^11.36.1
@@ -24,6 +24,8 @@ jobs:
                         carbon: ^2.63
                 exclude:
                     -   laravel: ^11.36.1
+                        php: 8.1
+                    -   laravel: ^12
                         php: 8.1
                     -   laravel: 9.*
                         php: 8.4

--- a/composer.json
+++ b/composer.json
@@ -30,14 +30,14 @@
     "prefer-stable": true,
     "require": {
         "php": "^8.1",
-        "illuminate/http": "^9.0|^10.0|^11.36.1",
-        "illuminate/support": "^9.0|^10.0|^11.36.1",
+        "illuminate/http": "^9.0|^10.0|^11.36.1|^12",
+        "illuminate/support": "^9.0|^10.0|^11.36.1|^12",
         "spatie/laravel-package-tools": "^1.17"
     },
     "require-dev": {
         "mockery/mockery": "^1.6.12",
-        "orchestra/testbench": "^7.0|^8.0|^9.9",
-        "pestphp/pest": "^1.23.0|^2.36.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.9|^10",
+        "pestphp/pest": "^1.23.0|^2.36.0|^3",
         "roave/security-advisories": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
## Summary
Laravel 12 isn't released yet, but everything is already prepared for it and so packages can already support it.

### Notes
- I removed the `include:` and explicit `nesbot/carbon`/`orchestra/testbench` part completely, because it would require to always fill it in for Laravel versions, which shouldn't be necessary -> composer will resolve the appropriate versions on its own to satisfy the primary `laravel/framework` dependency anyway