### PR TITLE
Cloudflare Turnstile preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,16 +138,17 @@ Alternatively, you can register your CSP policies as a meta tag using our Blade 
 
 This package ships with a few commonly used presets to get your started. *We're happy to receive PRs for more services!*
 
-| Policy              | Services                                                             |
-|---------------------|----------------------------------------------------------------------|
-| `Basic`       | Allow requests to scripts, images… within the application            |
-| `AdobeFonts`  | [fonts.adobe.com](https://fonts.adobe.com) (previously typekit.com)  |
-| `Fathom`      | [usefathom.com](https://usefathom.com)                               |
-| `Google`      | Google Analytics & Tag Manager                                       |       
-| `GoogleFonts` | [fonts.google.com](https://fonts.google.com)                         |       
-| `HubSpot`     | [hubspot.com](https://hubspot.com) (full suite)                      |       
-| `JsDelivr`          | [jsdelivr.com](https://jsdelivr.com)                                 |       
-| `Tolt`        | [tolt.io](https://tolt.io)                                           |       
+| Policy                 | Services                                                                              |
+|------------------------|---------------------------------------------------------------------------------------|
+| `Basic`                | Allow requests to scripts, images… within the application                             |
+| `AdobeFonts`           | [fonts.adobe.com](https://fonts.adobe.com) (previously typekit.com)                   |
+| `Cloudflare Turnstile` | [cloudflare.com](https://www.cloudflare.com/application-services/products/turnstile/) |
+| `Fathom`               | [usefathom.com](https://usefathom.com)                                                |
+| `Google`               | Google Analytics & Tag Manager                                                        |       
+| `GoogleFonts`          | [fonts.google.com](https://fonts.google.com)                                          |       
+| `HubSpot`              | [hubspot.com](https://hubspot.com) (full suite)                                       |       
+| `JsDelivr`             | [jsdelivr.com](https://jsdelivr.com)                                                  |       
+| `Tolt`                 | [tolt.io](https://tolt.io)                                                            |       
 
 Register the presets you want to use for your application in `config/csp.php` under the `presets` or `report_only_presets` key.
 

--- a/src/Presets/CloudflareTurnstile.php
+++ b/src/Presets/CloudflareTurnstile.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Csp\Presets;
+
+use Spatie\Csp\Directive;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Preset;
+
+class CloudflareTurnstile implements Preset
+{
+    public function configure(Policy $policy): void
+    {
+        $policy
+            ->add([Directive::FRAME, Directive::SCRIPT], 'https://challenges.cloudflare.com');
+    }
+}

--- a/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_CloudflareTurnstile______Spatie_Csp_Presets_CloudflareTurnstile__.snap
+++ b/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_CloudflareTurnstile______Spatie_Csp_Presets_CloudflareTurnstile__.snap
@@ -1,0 +1,2 @@
+frame-src https://challenges.cloudflare.com
+script-src https://challenges.cloudflare.com

--- a/tests/PresetTest.php
+++ b/tests/PresetTest.php
@@ -21,6 +21,7 @@ it(
 )->with([
     Presets\AdobeFonts::class,
     Presets\Basic::class,
+    Presets\CloudflareTurnstile::class,
     Presets\Fathom::class,
     Presets\GoogleFonts::class,
     Presets\GoogleAnalytics::class,


### PR DESCRIPTION
This PR adds a new preset, CloudflareTurnstile. It sets both frame-src and script-src to https://challenges.cloudflare.com - as noted by [Cloudflare's documentation](https://developers.cloudflare.com/turnstile/reference/content-security-policy/).