### PR TITLE
Ensure null values are removed

### DIFF
--- a/src/Policy.php
+++ b/src/Policy.php
@@ -36,7 +36,7 @@ class Policy
                 Arr::flatten(
                     array_map(function (Keyword|string $value) {
                         return $value instanceof Keyword ? $value : explode(' ', $value);
-                    }, Arr::wrap($values))
+                    }, array_filter(Arr::wrap($values)))
                 )
             );
 

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -338,6 +338,31 @@ it('will handle scheme values', function (): void {
     );
 });
 
+
+it('removes null values', function (): void {
+    $policy = new class implements Preset {
+        public function configure(Policy $policy): void
+        {
+            $policy->add(Directive::IMG, [
+                Scheme::DATA,
+                null,
+                Scheme::HTTPS,
+                null
+            ]);
+        }
+    };
+
+    config(['csp.presets' => [$policy::class]]);
+
+    $headers = getResponseHeaders();
+
+    assertEquals(
+        'img-src data: https:',
+        $headers->get('Content-Security-Policy')
+    );
+});
+
+
 it('can use an empty value for a directive', function (): void {
     $policy = new class implements Preset {
         public function configure(Policy $policy): void

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -347,7 +347,7 @@ it('removes null values', function (): void {
                 Scheme::DATA,
                 null,
                 Scheme::HTTPS,
-                null
+                null,
             ]);
         }
     };


### PR DESCRIPTION
Previously in version 2, null values wouldn't cause an issue and were ignored, 

In version 3,  they do ie 
```
TypeError: Spatie\Csp\Policy::Spatie\Csp\{closure}(): Argument #1 ($value) must be of type Spatie\Csp\Keyword|string, null given in /home/runner/work/app/app/vendor/spatie/laravel-csp/src/Policy.php:37 
```

This just ensures null values are removed, I think this is straight forward enough - a use case could be: 

```php
->add(Directive::FONT, [Keyword::SELF, $this->potentialNull()]);


public function potentialNull() : ?string
```
The null method may return null in a testing environment for example. 

I've added a test to make sure there's no regression too.