### PR TITLE
Skip CSP middleware when Laravel is rendering an exception

### DIFF
--- a/src/AddCspHeaders.php
+++ b/src/AddCspHeaders.php
@@ -19,6 +19,11 @@ class AddCspHeaders
             return $response;
         }
 
+        // Skip CSP middleware when Laravel is rendering an exception
+        if (config('app.debug') && $response->isServerError()) {
+            return $response;
+        }
+
         // Ensure custom CSP middleware registered later in the stack gets precedence
         if ($this->hasCspHeader($response)) {
             return $response;

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -2,8 +2,8 @@
 
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Route;
-use function PHPUnit\Framework\assertArrayNotHasKey;
 use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertNull;
 use function PHPUnit\Framework\assertStringContainsString;
 use Spatie\Csp\AddCspHeaders;
@@ -328,10 +328,7 @@ test('route middleware is skipped when laravel renders exceptions', function ():
         ->assertServerError()
         ->headers;
 
-    assertArrayNotHasKey(
-        'content-security-policy',
-        $headers,
-    );
+    assertFalse($headers->has('content-security-policy'));
 });
 
 it('will handle scheme values', function (): void {

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Route;
+use function PHPUnit\Framework\assertArrayNotHasKey;
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertNull;
 use function PHPUnit\Framework\assertStringContainsString;
@@ -312,6 +313,24 @@ test('route middleware will overwrite global middleware for that route', functio
     assertEquals(
         'base-uri custom-policy',
         $headers->get('Content-Security-Policy')
+    );
+});
+
+test('route middleware is skipped when laravel renders exceptions', function (): void {
+    config(['app.debug' => true]);
+
+    Route::get('other-route', function (): string {
+        throw new Exception('I am a server error');
+    })->middleware(AddCspHeaders::class.':'.Basic::class);
+
+    $headers = test()
+        ->get('other-route')
+        ->assertServerError()
+        ->headers;
+
+    assertArrayNotHasKey(
+        'content-security-policy',
+        $headers,
     );
 });
 


### PR DESCRIPTION
I've noticed since upgrading to v3 that Laravel's built-in exception rendering functionality doesn't display correctly, as the CSP middleware is still applied in this context. 

The following screenshot is the exception rendering page in a blank Laravel 12 application using the Basic preset:

![spatie-csp-debug test_](https://github.com/user-attachments/assets/d211e5f0-c377-4632-b650-3764ebf7e4c5)

This PR skips applying the CSP middleware if the application is in debug mode, and the response contains a server error. 

This felt like the simplest solution I could come up with to the problem, although I suppose an alternative could be to create a preset for the exception rendering page and return that  CSP middleware instead of no CSP middleware whatsoever. Any thoughts on the best approach would be appreciated.