### PR TITLE
Add Cloudflare Web Analytics preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,21 +138,22 @@ Alternatively, you can register your CSP policies as a meta tag using our Blade 
 
 This package ships with a few commonly used presets to get your started. *We're happy to receive PRs for more services!*
 
-| Policy                 | Services                                                                              |
-|------------------------|---------------------------------------------------------------------------------------|
-| `Basic`                | Allow requests to scripts, images… within the application                             |
-| `AdobeFonts`           | [fonts.adobe.com](https://fonts.adobe.com) (previously typekit.com)                   |
-| `Bunny Fonts`          | [fonts.bunny.net](https://fonts.bunny.net/)                                           |       
-| `Cloudflare Turnstile` | [cloudflare.com](https://www.cloudflare.com/application-services/products/turnstile/) |
-| `Fathom`               | [usefathom.com](https://usefathom.com)                                                |
-| `Google TLD's`         | Allow all Google Top Level Domains for 'connect' and 'image'                          |       
-| `Google`               | Google Analytics & Tag Manager                                                        |       
-| `GoogleFonts`          | [fonts.google.com](https://fonts.google.com)                                          |       
-| `HubSpot`              | [hubspot.com](https://hubspot.com) (full suite)                                       |       
-| `Intercom`             | [intercom.com](https://intercom.com/)                                                 |       
-| `JsDelivr`             | [jsdelivr.com](https://jsdelivr.com)                                                  |       
-| `Posthog`              | [posthog.com](https://posthog.com/)                                                   |       
-| `Tolt`                 | [tolt.io](https://tolt.io)                                                            |       
+| Policy                     | Services                                                                              |
+|----------------------------|---------------------------------------------------------------------------------------|
+| `Basic`                    | Allow requests to scripts, images… within the application                             |
+| `AdobeFonts`               | [fonts.adobe.com](https://fonts.adobe.com) (previously typekit.com)                   |
+| `Bunny Fonts`              | [fonts.bunny.net](https://fonts.bunny.net/)                                           |       
+| `Cloudflare Turnstile`     | [cloudflare.com](https://www.cloudflare.com/application-services/products/turnstile/) |
+| `Cloudflare Web Analytics` | [cloudflare.com](https://developers.cloudflare.com/web-analytics/)                    |
+| `Fathom`                   | [usefathom.com](https://usefathom.com)                                                |
+| `Google TLD's`             | Allow all Google Top Level Domains for 'connect' and 'image'                          |       
+| `Google`                   | Google Analytics & Tag Manager                                                        |       
+| `GoogleFonts`              | [fonts.google.com](https://fonts.google.com)                                          |       
+| `HubSpot`                  | [hubspot.com](https://hubspot.com) (full suite)                                       |       
+| `Intercom`                 | [intercom.com](https://intercom.com/)                                                 |       
+| `JsDelivr`                 | [jsdelivr.com](https://jsdelivr.com)                                                  |       
+| `Posthog`                  | [posthog.com](https://posthog.com/)                                                   |       
+| `Tolt`                     | [tolt.io](https://tolt.io)                                                            |       
 
 Register the presets you want to use for your application in `config/csp.php` under the `presets` or `report_only_presets` key.
 

--- a/src/Presets/CloudflareWebAnalytics.php
+++ b/src/Presets/CloudflareWebAnalytics.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\Csp\Presets;
+
+use Spatie\Csp\Directive;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Preset;
+
+class CloudflareWebAnalytics implements Preset
+{
+    public function configure(Policy $policy): void
+    {
+        $policy
+            ->add(Directive::CONNECT, 'cloudflareinsights.com')
+            ->add(Directive::SCRIPT, 'static.cloudflareinsights.com');
+    }
+}

--- a/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_Cloudflare…lytics______Spatie_Csp_Presets_Cloudflare___lytics__.snap
+++ b/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_Cloudflare…lytics______Spatie_Csp_Presets_Cloudflare___lytics__.snap
@@ -1,0 +1,2 @@
+connect-src cloudflareinsights.com
+script-src static.cloudflareinsights.com

--- a/tests/PresetTest.php
+++ b/tests/PresetTest.php
@@ -23,6 +23,7 @@ it(
     Presets\AdobeFonts::class,
     Presets\BunnyFonts::class,
     Presets\CloudflareTurnstile::class,
+    Presets\CloudflareWebAnalytics::class,
     Presets\Fathom::class,
     Presets\GoogleAnalytics::class,
     Presets\GoogleFonts::class,


### PR DESCRIPTION
This PR adds a preset for [Cloudflare Web Analytics](https://developers.cloudflare.com/web-analytics/). Documentation followed is here [https://developers.cloudflare.com/fundamentals/reference/policies-compliances/content-security-policies/](https://developers.cloudflare.com/fundamentals/reference/policies-compliances/content-security-policies/)