### PR TITLE
docs: remove return from v3 upgrade guide

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -46,7 +46,7 @@ Here's an example diff for a policy to preset refactor:
 -        return $this
 -            ->addDirective(Directive::SCRIPT, Keyword::SELF)
 -            ->addNonceForDirective(Directive::SCRIPT);
-+        return $policy
++        $policy
 +            ->add(Directive::SCRIPT, Keyword::SELF)
 +            ->addNonce(Directive::SCRIPT);
      }


### PR DESCRIPTION
The Preset interface requires a return type of `void`, so I think it's just a typo.