### PR TITLE
Skip CSP middleware when Vite is hot reloading

### DIFF
--- a/src/AddCspHeaders.php
+++ b/src/AddCspHeaders.php
@@ -4,6 +4,7 @@ namespace Spatie\Csp;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Vite;
 use Symfony\Component\HttpFoundation\Response;
 
 class AddCspHeaders
@@ -19,8 +20,8 @@ class AddCspHeaders
             return $response;
         }
 
-        // Skip CSP middleware when Laravel is rendering an exception
-        if (config('app.debug') && $response->isServerError()) {
+        // Skip CSP middleware when Laravel is rendering an exception or Vite is hot reloading
+        if (config('app.debug') && ($response->isServerError() || Vite::isRunningHot())) {
             return $response;
         }
 


### PR DESCRIPTION
This PR skips applying CSP middleware if the app is in debug mode and Vite is hot reloading, as applying CSP in this context (at least in my experience), isn't massively useful, since all the asset URLs are `http://localhost:5173`.