### PR TITLE
GoogleAnalytics Preset Missing Some URL's

### DIFF
--- a/src/Presets/GoogleAnalytics.php
+++ b/src/Presets/GoogleAnalytics.php
@@ -16,7 +16,9 @@ class GoogleAnalytics implements Preset
                 '*.analytics.google.com',
                 '*.g.doubleclick.net',
                 '*.google.com',
+                'pagead2.googlesyndication.com',
             ])
+            ->add([Directive::FRAME], 'td.doubleclick.net')
             ->addNonce(Directive::SCRIPT);
     }
 }

--- a/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_GoogleAnalytics______Spatie_Csp_Presets_GoogleAnalytics__.snap
+++ b/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_GoogleAnalytics______Spatie_Csp_Presets_GoogleAnalytics__.snap
@@ -1,3 +1,4 @@
-connect-src *.google-analytics.com *.analytics.google.com *.g.doubleclick.net *.google.com
-img-src *.google-analytics.com *.analytics.google.com *.g.doubleclick.net *.google.com
-script-src *.google-analytics.com *.analytics.google.com *.g.doubleclick.net *.google.com
+connect-src *.google-analytics.com *.analytics.google.com *.g.doubleclick.net *.google.com pagead2.googlesyndication.com
+img-src *.google-analytics.com *.analytics.google.com *.g.doubleclick.net *.google.com pagead2.googlesyndication.com
+script-src *.google-analytics.com *.analytics.google.com *.g.doubleclick.net *.google.com pagead2.googlesyndication.com
+frame-src td.doubleclick.net


### PR DESCRIPTION
Added `pagead2.googlesyndication.com` and `td.doubleclick.net`, according to Google's documentation:
https://developers.google.com/tag-platform/security/guides/csp#google_analytics_4_google_analytics