### PR TITLE
Add `Policy@setReportUri()` method

### DIFF
--- a/src/Policy.php
+++ b/src/Policy.php
@@ -76,6 +76,13 @@ class Policy
         return $this->add($directive, "'nonce-{$nonce}'");
     }
 
+    public function setReportUri(string $reportUri): self
+    {
+        $this->reportUri = $reportUri;
+
+        return $this;
+    }
+
     public function isEmpty(): bool
     {
         return empty($this->directives);


### PR DESCRIPTION
Previously we were able to override report uri using `$this->reportTo()` method inside policy.

```
class ReportOnlyContentSecurityPolicy extends Policy
{
    public function configure()
    {
        if ($reportUri = config('csp.report_only_policy_report_uri')) {
            $this->reportTo($reportUri);
        }

        // ...add directives...
    }
}
```

This was useful for setting custom report uri for report only policy.

Since v3, it's no longer possible. This PR makes this possible again:

```
class UseReportOnlyReportUri implements Preset
{
    public function configure(Policy $policy): void
    {
        if ($reportUri = config('csp.report_only_policy_report_uri')) {
            $policy->setReportUri($reportUri);
        }
    }
}
```

We use Datadog for ingesting CSP violations and have no way to distinguish "enforce" vs "report-only" violations without having separate report uris.