### PR TITLE
Docs|  Hint the usage of a base64-value for generated nonces

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,10 @@ class RandomString implements NonceGenerator
 }
 ```
 
+The generated nonce should be a **base64-value** derived from at least **16 bytes of secure random data**
+This limits the character set to characters safe for use in HTML attributes and HTTP headers.
+For more details, see the [W3C Content Security Policy Level 3 specification](https://www.w3.org/TR/CSP3/#grammardef-base64-value)
+
 ### Outputting a CSP Policy as a meta tag
 
 In rare circumstances, a large site may have so many external connections that the CSP header actually exceeds the max header size. Or you might be generating a static page with Laravel and don't have control over the headers when the response is sent. Thankfully, the [CSP specification](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#using_the_html_meta_element) allows for outputting information as a meta tag in the head of a webpage.

--- a/src/Nonce/NonceGenerator.php
+++ b/src/Nonce/NonceGenerator.php
@@ -4,5 +4,13 @@ namespace Spatie\Csp\Nonce;
 
 interface NonceGenerator
 {
+    /**
+     * Generates a CSP nonce string.
+     *
+     * The nonce should be a base64-value derived from at least 16 bytes of
+     * cryptographically secure random data, safe for use in HTML attributes and HTTP headers.
+     *
+     * @see https://www.w3.org/TR/CSP3/#grammardef-base64-value
+     */
     public function generate(): string;
 }


### PR DESCRIPTION
First of all, thanks Spatie for this great package

## Why? 
The W3C spec clarifies why we should use a base64-value for a nonce.

Currently I get the impression: "Hey, I can create my own nonce any way I like, it just has to be randomised for each request", until I hit a `\` or `+`,... and my headers or HTML break.

I hit this small detail whilst reading through the W3C spec, unfortunately I could not find the same notices in the MDN docs.

## What does this PR contribute?
This pull request only adds documentation
- The NonceGenerator's contract now hints the use of a base64-value as specified by the W3C spec 
  - I did not see many doc-blocks through the rest of the code, so I'm not sure if I am out of line by adding one.
- The README now also hints at the usage of a base64-value

Illuminate's `Str::random()` already generates a `base64-value` as far as I understand it, so I did not see the need to introduce any changes to the existing logic.