### PR TITLE
Fix Trusted Types keyword and clarify Preset interface implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ return [
 
     /*
      * Presets will determine which CSP headers will be set. A valid CSP preset is
-     * any class that extends `Spatie\Csp\Preset`
+     * any class that implements `Spatie\Csp\Preset`
      */
     'presets' => [
         Spatie\Csp\Presets\Basic::class,

--- a/config/csp.php
+++ b/config/csp.php
@@ -7,7 +7,7 @@ return [
 
     /*
      * Presets will determine which CSP headers will be set. A valid CSP preset is
-     * any class that extends `Spatie\Csp\Preset`
+     * any class that implements `Spatie\Csp\Preset`
      */
     'presets' => [
         Spatie\Csp\Presets\Basic::class,

--- a/src/Exceptions/InvalidPreset.php
+++ b/src/Exceptions/InvalidPreset.php
@@ -11,6 +11,6 @@ class InvalidPreset extends Exception
     {
         $className = $class::class;
 
-        return new self("The CSP class `{$className}` is not valid. A valid policy extends ".Preset::class);
+        return new self("The CSP class `{$className}` is not valid. A valid policy implements ".Preset::class);
     }
 }

--- a/src/Keyword.php
+++ b/src/Keyword.php
@@ -6,6 +6,7 @@ enum Keyword: string
 {
     case NONE = 'none';
     case REPORT_SAMPLE = 'report-sample';
+    case SCRIPT = 'script';
     case SELF = 'self';
     case STRICT_DYNAMIC = 'strict-dynamic';
     case UNSAFE_EVAL = 'unsafe-eval';


### PR DESCRIPTION
- Missing script keyword for `require-trusted-types-for` directive (added to `Keyword.php`)
- Clarifies that custom presets must implement, not extend, the Preset interface (README and error message fixes)
- Minor comment wording adjustments in config and exceptions