### PR TITLE
Feat: add algolia preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This package ships with a few commonly used presets to get your started. *We're 
 |----------------------------|---------------------------------------------------------------------------------------|
 | `Basic`                    | Allow requests to scripts, images… within the application                             |
 | `AdobeFonts`               | [fonts.adobe.com](https://fonts.adobe.com) (previously typekit.com)                   |
-| `Algolia`.                 | [algolia.com](https://www.algolia.com).                                               |
+| `Algolia`                  | [algolia.com](https://www.algolia.com)                                                |
 | `Bunny Fonts`              | [fonts.bunny.net](https://fonts.bunny.net/)                                           |       
 | `Cloudflare Turnstile`     | [cloudflare.com](https://www.cloudflare.com/application-services/products/turnstile/) |
 | `Cloudflare Web Analytics` | [cloudflare.com](https://developers.cloudflare.com/web-analytics/)                    |

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ This package ships with a few commonly used presets to get your started. *We're 
 |----------------------------|---------------------------------------------------------------------------------------|
 | `Basic`                    | Allow requests to scripts, images… within the application                             |
 | `AdobeFonts`               | [fonts.adobe.com](https://fonts.adobe.com) (previously typekit.com)                   |
+| `Algolia`.                 | [algolia.com](https://www.algolia.com).                                               |
 | `Bunny Fonts`              | [fonts.bunny.net](https://fonts.bunny.net/)                                           |       
 | `Cloudflare Turnstile`     | [cloudflare.com](https://www.cloudflare.com/application-services/products/turnstile/) |
 | `Cloudflare Web Analytics` | [cloudflare.com](https://developers.cloudflare.com/web-analytics/)                    |

--- a/src/Presets/Algolia.php
+++ b/src/Presets/Algolia.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\Csp\Presets;
+
+use Spatie\Csp\Directive;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Preset;
+
+class Algolia implements Preset
+{
+    public function configure(Policy $policy): void
+    {
+        $policy
+            ->add(Directive::CONNECT, [
+                'https://*.algolia.net',
+                'https://*.algolianet.com',
+            ]);
+    }
+}


### PR DESCRIPTION
This pull request adds a new Content Security Policy (CSP) preset for Algolia, making it easier for users to allow connections to Algolia's domains. It also updates the documentation to include this new preset.

New Algolia CSP preset:

* Added a new `Algolia` preset in `src/Presets/Algolia.php` that allows `CONNECT` requests to `*.algolia.net` and `*.algolianet.com` domains.

Documentation update:

* Updated the `README.md` to list the new `Algolia` preset among the available CSP presets.