### PR TITLE
feat: whereby CSP preset added

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ This package ships with a few commonly used presets to get your started. *We're 
 | `TicketTailor`             | [tickettailor.com](https://www.tickettailor.com)                                      |
 | `Tolt`                     | [tolt.io](https://tolt.io)                                                            |
 | `Vimeo`                    | [vimeo.com](https://vimeo.com)                                                        |
+| `Whereby`                  | [whereby.com](https://whereby.com)                                                    |
 
 Register the presets you want to use for your application in `config/csp.php` under the `presets` or `report_only_presets` key.
 

--- a/src/Presets/Whereby.php
+++ b/src/Presets/Whereby.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Csp\Presets;
+
+use Spatie\Csp\Directive;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Preset;
+
+class Whereby implements Preset
+{
+    public function configure(Policy $policy): void
+    {
+        $policy
+            ->add([Directive::SCRIPT, Directive::FRAME], [
+                'https://*.whereby.com',
+            ]);
+    }
+}


### PR DESCRIPTION
This pull request adds support for Whereby as a new Content Security Policy (CSP) preset. The main changes include the creation of a new `Whereby` preset class and updating the documentation to list Whereby among the available presets.

**New preset addition:**

* Added a new `Whereby` CSP preset by creating the `Whereby` class in `src/Presets/Whereby.php`, which configures the policy to allow scripts and frames from `https://*.whereby.com`.

**Documentation update:**

* Updated the `README.md` to include `Whereby` in the list of available presets.