### PR TITLE
feat: sentry preset added

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This package ships with a few commonly used presets to get your started. *We're 
 | `Microsoft Clarity`        | [clarity.microsoft.com](https://clarity.microsoft.com)                                |
 | `Plausible Analytics`      | [plausible.io](http://plausible.io/)                                                  |
 | `Posthog`                  | [posthog.com](https://posthog.com/)                                                   |       
+| `Sentry`                   | [sentry.io](https://sentry.io/)                                                       |
 | `Stripe`                   | [stripe.com](https://stripe.com/)                                                     |
 | `TicketTailor`             | [tickettailor.com](https://www.tickettailor.com)                                      |
 | `Tolt`                     | [tolt.io](https://tolt.io)                                                            |

--- a/src/Presets/Sentry.php
+++ b/src/Presets/Sentry.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Csp\Presets;
+
+use Spatie\Csp\Directive;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Preset;
+
+class Sentry implements Preset
+{
+    public function configure(Policy $policy): void
+    {
+        $policy
+            ->add(Directive::CONNECT, [
+                'https://*.ingest.us.sentry.io',
+            ]);
+    }
+}


### PR DESCRIPTION
This pull request adds support for Sentry as a preset in the package, making it easier for users to configure Content Security Policy (CSP) rules for Sentry integrations. The main changes include updating the documentation to list Sentry as a built-in preset and introducing a new `Sentry` preset class.

**Documentation update:**

* Added Sentry to the list of available presets in the `README.md` file, including a link to sentry.io.

**New preset implementation:**

* Created a new `Sentry` preset class in `src/Presets/Sentry.php` that configures the CSP policy to allow connections to Sentry's US ingest endpoint.