### PR TITLE
feat: add cloudflare cdn preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ This package ships with a few commonly used presets to get your started. *We're 
 | `AdobeFonts`               | [fonts.adobe.com](https://fonts.adobe.com) (previously typekit.com)                   |
 | `Algolia`                  | [algolia.com](https://www.algolia.com)                                                |
 | `Bunny Fonts`              | [fonts.bunny.net](https://fonts.bunny.net/)                                           |       
+| `Cloudflare Cdn`           | [cloudflare.com](https://www.cloudflare.com/en-in/application-services/products/cdn/) |
 | `Cloudflare Turnstile`     | [cloudflare.com](https://www.cloudflare.com/application-services/products/turnstile/) |
 | `Cloudflare Web Analytics` | [cloudflare.com](https://developers.cloudflare.com/web-analytics/)                    |
 | `Fathom`                   | [usefathom.com](https://usefathom.com)                                                |

--- a/src/Presets/CloudflareCdn.php
+++ b/src/Presets/CloudflareCdn.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Csp\Presets;
+
+use Spatie\Csp\Directive;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Preset;
+
+class CloudflareCdn implements Preset
+{
+    public function configure(Policy $policy): void
+    {
+        $policy
+            ->add([Directive::STYLE, Directive::SCRIPT], [
+                'https://cdnjs.cloudflare.com',
+            ]);
+    }
+}


### PR DESCRIPTION
This pull request adds support for Cloudflare CDN as a new preset in the package. The main changes include updating the documentation to list the new preset and introducing a new preset class that configures the appropriate Content Security Policy (CSP) directives for Cloudflare CDN.

**Cloudflare CDN preset addition:**

* Added `Cloudflare Cdn` to the list of available presets in the `README.md` documentation, including a link to the Cloudflare CDN product page.
* Introduced a new `CloudflareCdn` preset class in `src/Presets/CloudflareCdn.php`, which configures the CSP policy to allow styles and scripts from `https://cdnjs.cloudflare.com`.