### PR TITLE
feat: added google lookerstudio preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ This package ships with a few commonly used presets to get your started. *We're 
 | `Google TLD's`             | Allow all Google Top Level Domains for 'connect' and 'image'                          |       
 | `Google`                   | Google Analytics & Tag Manager                                                        |       
 | `GoogleFonts`              | [fonts.google.com](https://fonts.google.com)                                          | 
+| `GoogleLookerStudio`       | [lookerstudio.google.com](https://lookerstudio.google.com)                            | 
 | `GoogleRecaptcha`          | [developers.google.com](https://developers.google.com/recaptcha)                      | 
 | `Hcaptcha`                 | [hcaptcha.com](https://docs.hcaptcha.com)                                             |
 | `Hireroad`                 | [hireroad.com](https://hireroad.com)                                               |

--- a/src/Presets/GoogleLookerStudio.php
+++ b/src/Presets/GoogleLookerStudio.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Csp\Presets;
+
+use Spatie\Csp\Directive;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Preset;
+
+class GoogleLookerStudio implements Preset
+{
+    public function configure(Policy $policy): void
+    {
+        $policy
+            ->add(Directive::FRAME, [
+                'https://lookerstudio.google.com',
+            ]);
+    }
+}


### PR DESCRIPTION
This pull request adds support for Google Looker Studio to the package's Content Security Policy (CSP) presets. The main changes include updating the documentation to list the new preset and introducing a new preset class for Looker Studio.

**Documentation update:**

* Added `GoogleLookerStudio` to the list of available CSP presets in the `README.md`.

**New preset implementation:**

* Added a new `GoogleLookerStudio` preset class in `src/Presets/GoogleLookerStudio.php`, allowing frames from `https://lookerstudio.google.com`.