### PR TITLE
feat: add jquery preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ This package ships with a few commonly used presets to get your started. *We're 
 | `HubSpot`                  | [hubspot.com](https://hubspot.com) (full suite)                                       |       
 | `Intercom`                 | [intercom.com](https://intercom.com/)                                                 |       
 | `JsDelivr`                 | [jsdelivr.com](https://jsdelivr.com)                                                  |  
+| `JQuery`                   | [jquery.com](https://jquery.com)                                                      |  
 | `Meta Pixel`               | [facebook.com](https://en-gb.facebook.com/business/tools/meta-pixel)                  |       
 | `Microsoft Clarity`        | [clarity.microsoft.com](https://clarity.microsoft.com)                                |
 | `Plausible Analytics`      | [plausible.io](http://plausible.io/)                                                  |

--- a/src/Presets/JQuery.php
+++ b/src/Presets/JQuery.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Csp\Presets;
+
+use Spatie\Csp\Directive;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Preset;
+
+class JQuery implements Preset
+{
+    public function configure(Policy $policy): void
+    {
+        $policy
+            ->add(Directive::SCRIPT, [
+                'https://code.jquery.com',
+            ]);
+    }
+}


### PR DESCRIPTION
This pull request adds support for a new Content Security Policy (CSP) preset for jQuery. The main changes include introducing a new `JQuery` preset class and updating the documentation to reflect its availability.

**New preset addition:**

* Added a new `JQuery` preset class in `src/Presets/JQuery.php`, which configures the CSP policy to allow scripts from `https://code.jquery.com`.

**Documentation update:**

* Updated `README.md` to include `JQuery` in the list of available CSP presets, with a link to [jquery.com](https://jquery.com).