### PR TITLE
feat: heap analytics preset added

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ This package ships with a few commonly used presets to get your started. *We're 
 | `GoogleFonts`              | [fonts.google.com](https://fonts.google.com)                                          | 
 | `GoogleRecaptcha`          | [developers.google.com](https://developers.google.com/recaptcha)                      | 
 | `Hcaptcha`                 | [hcaptcha.com](https://docs.hcaptcha.com)                                             |
+| `Heap Analytics`           | [heap.io](https://www.heap.io/)                                                       |
 | `Hireroad`                 | [hireroad.com](https://hireroad.com)                                               |
 | `Hotjar`                   | [hotjar.com](https://help.hotjar.com/hc/en-us/articles/115011640307-Content-Security-Policies) | 
 | `HubSpot`                  | [hubspot.com](https://hubspot.com) (full suite)                                       |       

--- a/src/Presets/HeapAnalytics.php
+++ b/src/Presets/HeapAnalytics.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\Csp\Presets;
+
+use Spatie\Csp\Directive;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Preset;
+
+class HeapAnalytics implements Preset
+{
+    public function configure(Policy $policy): void
+    {
+        $policy
+            ->add(Directive::SCRIPT, [
+                'https://cdn.heapanalytics.com',
+            ])
+            ->add([Directive::IMG, Directive::CONNECT], [
+                'https://heapanalytics.com',
+            ]);
+    }
+}


### PR DESCRIPTION
This pull request adds support for Heap Analytics as a new preset in the package. The main changes include the implementation of the `HeapAnalytics` preset and updating the documentation to reflect this addition.

**New Heap Analytics preset:**

* Added a new `HeapAnalytics` class in `src/Presets/HeapAnalytics.php` to define the necessary Content Security Policy (CSP) directives for Heap Analytics. This includes allowing scripts from `https://cdn.heapanalytics.com` and image/connect requests to `https://heapanalytics.com`.

**Documentation update:**

* Updated the `README.md` to include `Heap Analytics` in the list of available presets, with a link to the Heap Analytics website.