### PR TITLE
feat: add maze preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ This package ships with a few commonly used presets to get your started. *We're 
 | `HubSpot`                  | [hubspot.com](https://hubspot.com) (full suite)                                       |       
 | `Intercom`                 | [intercom.com](https://intercom.com/)                                                 |       
 | `JsDelivr`                 | [jsdelivr.com](https://jsdelivr.com)                                                  |  
+| `Maze`                     | [maze.co](https://maze.co)                  |       
 | `Meta Pixel`               | [facebook.com](https://en-gb.facebook.com/business/tools/meta-pixel)                  |       
 | `Microsoft Clarity`        | [clarity.microsoft.com](https://clarity.microsoft.com)                                |
 | `Plausible Analytics`      | [plausible.io](http://plausible.io/)                                                  |

--- a/src/Presets/Maze.php
+++ b/src/Presets/Maze.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\Csp\Presets;
+
+use Spatie\Csp\Directive;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Preset;
+
+class Maze implements Preset
+{
+    public function configure(Policy $policy): void
+    {
+        $policy
+            ->add(Directive::SCRIPT, [
+                'https://snippet.maze.co',
+            ])
+            ->add(Directive::CONNECT, [
+                'https://prompts.maze.co',
+            ]);
+    }
+}


### PR DESCRIPTION
This pull request adds support for the Maze analytics tool by introducing a new preset. The main changes are the addition of the `Maze` preset class and its documentation in the list of available presets.

New preset for Maze analytics:

* Added a new `Maze` preset class in `src/Presets/Maze.php`, which configures the necessary CSP directives for Maze by allowing scripts from `https://snippet.maze.co` and connections to `https://prompts.maze.co`.

Documentation update:

* Updated the `README.md` to include `Maze` in the list of commonly used presets, with a link to [maze.co](https://maze.co).