### PR TITLE
feat: add vwo preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ This package ships with a few commonly used presets to get your started. *We're 
 | `TicketTailor`             | [tickettailor.com](https://www.tickettailor.com)                                      |
 | `Tolt`                     | [tolt.io](https://tolt.io)                                                            |
 | `Vimeo`                    | [vimeo.com](https://vimeo.com)                                                        |
+| `Visual Website Optimizer` | [vwo.com](https://vwo.com)                                                        |
 | `Whereby`                  | [whereby.com](https://whereby.com)                                                    |
 
 Register the presets you want to use for your application in `config/csp.php` under the `presets` or `report_only_presets` key.

--- a/src/Presets/VisualWebsiteOptimizer.php
+++ b/src/Presets/VisualWebsiteOptimizer.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\Csp\Presets;
+
+use Spatie\Csp\Directive;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Preset;
+
+class VisualWebsiteOptimizer implements Preset
+{
+    public function configure(Policy $policy): void
+    {
+        $policy
+            ->add([Directive::SCRIPT, Directive::IMG, Directive::CONNECT], [
+                'blob:',
+                'https://dev.visualwebsiteoptimizer.com',
+            ]);
+    }
+}


### PR DESCRIPTION
This pull request adds support for Visual Website Optimizer (VWO) as a new Content Security Policy (CSP) preset. The main changes include updating the documentation to list VWO as an available preset and introducing a new preset class for VWO.

**New Visual Website Optimizer preset:**

* Added `Visual Website Optimizer` to the list of available presets in the `README.md` documentation.
* Introduced a new `VisualWebsiteOptimizer` preset class in `src/Presets/VisualWebsiteOptimizer.php`, which configures the CSP policy to allow relevant script, image, and connect sources for VWO.