### PR TITLE
feat: add bootstrap preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ This package ships with a few commonly used presets to get your started. *We're 
 | `Basic`                    | Allow requests to scripts, images… within the application                             |
 | `AdobeFonts`               | [fonts.adobe.com](https://fonts.adobe.com) (previously typekit.com)                   |
 | `Algolia`                  | [algolia.com](https://www.algolia.com)                                                |
+| `Bootstrap`                | [getbootstrap.com](https://getbootstrap.com)                                          |       
 | `Bunny Fonts`              | [fonts.bunny.net](https://fonts.bunny.net/)                                           |       
 | `Cloudflare Turnstile`     | [cloudflare.com](https://www.cloudflare.com/application-services/products/turnstile/) |
 | `Cloudflare Web Analytics` | [cloudflare.com](https://developers.cloudflare.com/web-analytics/)                    |

--- a/src/Presets/Bootstrap.php
+++ b/src/Presets/Bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\Csp\Presets;
+
+use Spatie\Csp\Directive;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Preset;
+
+class Bootstrap implements Preset
+{
+    public function configure(Policy $policy): void
+    {
+        $policy
+            ->add([Directive::STYLE, Directive::FONT], [
+                'data:',
+                'https://maxcdn.bootstrapcdn.com',
+            ]);
+    }
+}


### PR DESCRIPTION
This pull request adds a new Content Security Policy (CSP) preset for Bootstrap, making it easier to configure CSP rules for projects using Bootstrap resources. The most important changes are:

**New Bootstrap CSP Preset:**

* Added a new `Bootstrap` preset class in `src/Presets/Bootstrap.php` that configures the CSP policy to allow styles and fonts from `data:` and `https://maxcdn.bootstrapcdn.com`.

**Documentation Update:**

* Updated the `README.md` to include the new `Bootstrap` preset in the list of commonly used presets, providing visibility and usage instructions for users.