### PR TITLE
Fix: vimeo preset

### DIFF
--- a/src/Presets/Vimeo.php
+++ b/src/Presets/Vimeo.php
@@ -11,8 +11,7 @@ class Vimeo implements Preset
     public function configure(Policy $policy): void
     {
         $policy
-            ->add(Directive::SCRIPT, 'player.vimeo.com')
-            ->add(Directive::FRAME, 'player.vimeo.com')
+            ->add([Directive::SCRIPT, Directive::FRAME], 'player.vimeo.com')
             ->add(Directive::CONNECT, 'vimeo.com')
             ->add(Directive::IMG, '*.vimeocdn.com');
     }

--- a/src/Presets/Vimeo.php
+++ b/src/Presets/Vimeo.php
@@ -11,7 +11,6 @@ class Vimeo implements Preset
     public function configure(Policy $policy): void
     {
         $policy
-            ->add(Directive::SCRIPT, 'player.vimeo.com')
-            ->add(Directive::FRAME, 'player.vimeo.com');
+            ->add([Directive::SCRIPT, Directive::FRAME], 'player.vimeo.com');
     }
 }

--- a/src/Presets/Vimeo.php
+++ b/src/Presets/Vimeo.php
@@ -11,6 +11,8 @@ class Vimeo implements Preset
     public function configure(Policy $policy): void
     {
         $policy
-            ->add([Directive::SCRIPT, Directive::FRAME], 'player.vimeo.com');
+            ->add([Directive::SCRIPT, Directive::FRAME], 'player.vimeo.com')
+            ->add(Directive::CONNECT, ['vimeo.com'])
+            ->add(Directive::IMG, ['*.vimeocdn.com']);
     }
 }

--- a/src/Presets/Vimeo.php
+++ b/src/Presets/Vimeo.php
@@ -11,8 +11,9 @@ class Vimeo implements Preset
     public function configure(Policy $policy): void
     {
         $policy
-            ->add([Directive::SCRIPT, Directive::FRAME], ['player.vimeo.com'])
-            ->add(Directive::CONNECT, ['vimeo.com'])
-            ->add(Directive::IMG, ['*.vimeocdn.com']);
+            ->add(Directive::SCRIPT, 'player.vimeo.com')
+            ->add(Directive::FRAME, 'player.vimeo.com')
+            ->add(Directive::CONNECT, 'vimeo.com')
+            ->add(Directive::IMG, '*.vimeocdn.com');
     }
 }

--- a/src/Presets/Vimeo.php
+++ b/src/Presets/Vimeo.php
@@ -11,7 +11,7 @@ class Vimeo implements Preset
     public function configure(Policy $policy): void
     {
         $policy
-            ->add([Directive::SCRIPT, Directive::FRAME], 'player.vimeo.com')
+            ->add([Directive::SCRIPT, Directive::FRAME], ['player.vimeo.com'])
             ->add(Directive::CONNECT, ['vimeo.com'])
             ->add(Directive::IMG, ['*.vimeocdn.com']);
     }

--- a/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_Vimeo______Spatie_Csp_Presets_Vimeo__.snap
+++ b/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_Vimeo______Spatie_Csp_Presets_Vimeo__.snap
@@ -1,2 +1,4 @@
 script-src player.vimeo.com
 frame-src player.vimeo.com
+connect-src vimeo.com
+img-src *.vimeocdn.com


### PR DESCRIPTION
This pull request updates the `Vimeo` preset configuration to improve Content Security Policy (CSP) handling by consolidating directive additions and expanding allowed sources for specific content types.

**CSP directive improvements:**

* Combined the addition of `SCRIPT` and `FRAME` directives for `'player.vimeo.com'` into a single call for cleaner code and easier maintenance.
* Added the `CONNECT` directive to allow connections to `'vimeo.com'`, supporting features that require API or data requests.
* Added the `IMG` directive to permit images from `'*.vimeocdn.com'`, ensuring embedded Vimeo content can load necessary images.