### PR TITLE
Add European/German location URL for Sentry

### DIFF
--- a/src/Presets/Sentry.php
+++ b/src/Presets/Sentry.php
@@ -12,6 +12,7 @@ class Sentry implements Preset
     {
         $policy
             ->add(Directive::CONNECT, [
+                'https://*.ingest.de.sentry.io',
                 'https://*.ingest.us.sentry.io',
             ]);
     }


### PR DESCRIPTION
Sentry documentation for Data Storage Locations: https://docs.sentry.io/organization/data-storage-location/