### PR TITLE
Fix: update JsDelivr preset to include connect-src directive

### DIFF
--- a/src/Presets/JsDelivr.php
+++ b/src/Presets/JsDelivr.php
@@ -12,6 +12,6 @@ class JsDelivr implements Preset
     public function configure(Policy $policy): void
     {
         $policy
-            ->add([Directive::SCRIPT, Directive::STYLE, Directive::FONT], 'cdn.jsdelivr.net');
+            ->add([Directive::SCRIPT, Directive::STYLE, Directive::FONT, Directive::CONNECT], 'cdn.jsdelivr.net');
     }
 }

--- a/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_JsDelivr______Spatie_Csp_Presets_JsDelivr__.snap
+++ b/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_JsDelivr______Spatie_Csp_Presets_JsDelivr__.snap
@@ -1,3 +1,4 @@
 script-src cdn.jsdelivr.net
 style-src cdn.jsdelivr.net
 font-src cdn.jsdelivr.net
+connect-src cdn.jsdelivr.net


### PR DESCRIPTION
This pull request updates the `JsDelivr` CSP preset to allow connections to the jsDelivr CDN for resources loaded via the `connect-src` directive, in addition to the previously allowed script, style, and font sources. The corresponding test snapshot has also been updated to reflect this change.

CSP policy update:

* Added `Directive::CONNECT` to the list of allowed directives for `cdn.jsdelivr.net` in the `JsDelivr` preset, enabling connections such as AJAX or WebSocket requests to the CDN. (`src/Presets/JsDelivr.php`)

Test update:

* Updated the test snapshot to include `connect-src cdn.jsdelivr.net`, ensuring the test accurately represents the new policy. (`tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_JsDelivr______Spatie_Csp_Presets_JsDelivr__.snap`)