### PR TITLE
Feat: add SurveyMonkey preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This package ships with a few commonly used presets to get your started. *We're 
 |----------------------------|---------------------------------------------------------------------------------------|
 | `Basic`                    | Allow requests to scripts, images… within the application                             |
 | `AdobeFonts`               | [fonts.adobe.com](https://fonts.adobe.com) (previously typekit.com)                   |
-| `Alchemer Survey`          | [alchemer.com](https://www.alchemer.com)                                                |
+| `Alchemer Survey`          | [alchemer.com](https://www.alchemer.com)                                              |
 | `Algolia`                  | [algolia.com](https://www.algolia.com)                                                |
 | `Bootstrap`                | [getbootstrap.com](https://getbootstrap.com)                                          |       
 | `Bunny Fonts`              | [fonts.bunny.net](https://fonts.bunny.net/)                                           |       
@@ -185,6 +185,7 @@ This package ships with a few commonly used presets to get your started. *We're 
 | `Posthog`                  | [posthog.com](https://posthog.com/)                                                   |       
 | `Sentry`                   | [sentry.io](https://sentry.io/)                                                       |
 | `Stripe`                   | [stripe.com](https://stripe.com/)                                                     |
+| `SurveyMonkey`             | [surveymonkey.com](https://www.surveymonkey.com/)                                     |
 | `TicketTailor`             | [tickettailor.com](https://www.tickettailor.com)                                      |
 | `Tolt`                     | [tolt.io](https://tolt.io)                                                            |
 | `Vimeo`                    | [vimeo.com](https://vimeo.com)                                                        |

--- a/src/Presets/SurveyMonkey.php
+++ b/src/Presets/SurveyMonkey.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Csp\Presets;
+
+use Spatie\Csp\Directive;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Preset;
+
+class SurveyMonkey implements Preset
+{
+    public function configure(Policy $policy): void
+    {
+        $policy
+            ->add(Directive::FRAME, ['https://www.surveymonkey.com']);
+    }
+}

--- a/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_SurveyMonkey______Spatie_Csp_Presets_SurveyMonkey__.snap
+++ b/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_SurveyMonkey______Spatie_Csp_Presets_SurveyMonkey__.snap
@@ -1,0 +1,1 @@
+frame-src https://www.surveymonkey.com

--- a/tests/PresetTest.php
+++ b/tests/PresetTest.php
@@ -50,6 +50,7 @@ it(
     Presets\Posthog::class,
     Presets\Sentry::class,
     Presets\Stripe::class,
+    Presets\SurveyMonkey::class,
     Presets\TicketTailor::class,
     Presets\Tolt::class,
     Presets\Vimeo::class,


### PR DESCRIPTION
This pull request adds support for SurveyMonkey as a preset in the package, allowing users to easily configure Content Security Policy (CSP) settings for SurveyMonkey integrations. The main changes involve introducing the new `SurveyMonkey` preset, updating documentation, and adding corresponding tests.

**SurveyMonkey Preset Integration:**

* Added a new `SurveyMonkey` preset class (`src/Presets/SurveyMonkey.php`) that configures the CSP to allow framing from `https://www.surveymonkey.com`.
* Updated the list of available presets in the documentation to include SurveyMonkey (`README.md`).

**Testing:**

* Added the `SurveyMonkey` preset to the preset test suite (`tests/PresetTest.php`).
* Added a snapshot test to verify the CSP stringification for the `SurveyMonkey` preset (`tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_SurveyMonkey______Spatie_Csp_Presets_SurveyMonkey__.snap`).