### PR TITLE
Change 'report_uri' to 'report_to'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,7 +213,7 @@ All notable changes to `laravel-csp` will be documented in this file
 ### What's Changed
 
 * Update README.md by @nessimabadi in https://github.com/spatie/laravel-csp/pull/162
-* Ensure correct report_uri is applied for report-only CSP policies by @andrextor in https://github.com/spatie/laravel-csp/pull/164
+* Ensure correct report_to is applied for report-only CSP policies by @andrextor in https://github.com/spatie/laravel-csp/pull/164
 
 ### New Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,7 +213,7 @@ All notable changes to `laravel-csp` will be documented in this file
 ### What's Changed
 
 * Update README.md by @nessimabadi in https://github.com/spatie/laravel-csp/pull/162
-* Ensure correct report_to is applied for report-only CSP policies by @andrextor in https://github.com/spatie/laravel-csp/pull/164
+* Ensure correct report_uri is applied for report-only CSP policies by @andrextor in https://github.com/spatie/laravel-csp/pull/164
 
 ### New Contributors
 

--- a/README.md
+++ b/README.md
@@ -256,20 +256,19 @@ public function configure(Policy $policy): void
 }
 ```
 
-There are also a few cases where you don't have to or don't need to specify a value, eg. upgrade-insecure-requests, block-all-mixed-content, ... In this case you can use the following value:
+There are also a few cases where you don't have to or don't need to specify a value, eg. upgrade-insecure-requests, ... In this case you can use the following value:
 
 ```php
 public function configure(Policy $policy): void
 {
     $policy
-        ->add(Directive::UPGRADE_INSECURE_REQUESTS, Value::NO_VALUE)
-        ->add(Directive::BLOCK_ALL_MIXED_CONTENT, Value::NO_VALUE);
+        ->add(Directive::UPGRADE_INSECURE_REQUESTS, Value::NO_VALUE);
 }
 ```
 
 This will output a CSP like this:
 ```
-Content-Security-Policy: upgrade-insecure-requests;block-all-mixed-content
+Content-Security-Policy: upgrade-insecure-requests
 ```
 
 The `presets` key of the `csp` config file is set to `[\Spatie\Csp\Presets\Basic::class]` by default. This class allows your site to only use images, scripts, form actions of your own site.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ return [
      * All violations against a policy will be reported to this url.
      * A great service you could use for this is https://report-uri.com/
      */
-    'report_uri' => env('CSP_REPORT_URI', ''),
+    'report_to' => env('CSP_REPORT_TO', ''),
 
     /*
      * Headers will only be added if this setting is set to true.
@@ -256,19 +256,20 @@ public function configure(Policy $policy): void
 }
 ```
 
-There are also a few cases where you don't have to or don't need to specify a value, eg. upgrade-insecure-requests, ... In this case you can use the following value:
+There are also a few cases where you don't have to or don't need to specify a value, eg. upgrade-insecure-requests, block-all-mixed-content, ... In this case you can use the following value:
 
 ```php
 public function configure(Policy $policy): void
 {
     $policy
-        ->add(Directive::UPGRADE_INSECURE_REQUESTS, Value::NO_VALUE);
+        ->add(Directive::UPGRADE_INSECURE_REQUESTS, Value::NO_VALUE)
+        ->add(Directive::BLOCK_ALL_MIXED_CONTENT, Value::NO_VALUE);
 }
 ```
 
 This will output a CSP like this:
 ```
-Content-Security-Policy: upgrade-insecure-requests
+Content-Security-Policy: upgrade-insecure-requests;block-all-mixed-content
 ```
 
 The `presets` key of the `csp` config file is set to `[\Spatie\Csp\Presets\Basic::class]` by default. This class allows your site to only use images, scripts, form actions of your own site.
@@ -458,7 +459,7 @@ Instead of outright blocking all violations, you can put configure a CSP policy 
 
 #### To an external url
 
-Any violations against the policy can be reported to a given url. You can set that url in the `report_uri` key of the `csp` config file. A great service that is specifically built for handling these violation reports is [http://report-uri.io/](http://report-uri.io/). 
+Any violations against the policy can be reported to a given url. You can set that url in the `report_to` key of the `csp` config file. A great service that is specifically built for handling these violation reports is [http://report-uri.io/](http://report-uri.io/). 
 
 ### Testing
 

--- a/config/csp.php
+++ b/config/csp.php
@@ -39,7 +39,7 @@ return [
      * All violations against a policy will be reported to this url.
      * A great service you could use for this is https://report-uri.com/
      */
-    'report_uri' => env('CSP_REPORT_URI', ''),
+    'report_to' => env('CSP_REPORT_TO', ''),
 
     /*
      * Headers will only be added if this setting is set to true.

--- a/src/AddCspHeaders.php
+++ b/src/AddCspHeaders.php
@@ -46,7 +46,7 @@ class AddCspHeaders
         $policy = Policy::create(
             presets: config('csp.presets'),
             directives: config('csp.directives'),
-            reportUri: config('csp.report_uri'),
+            reportTo: config('csp.report_to'),
         );
 
         if (! $policy->isEmpty()) {
@@ -56,7 +56,7 @@ class AddCspHeaders
         $reportOnlyPolicy = Policy::create(
             presets: config('csp.report_only_presets'),
             directives: config('csp.report_only_directives'),
-            reportUri: config('csp.report_uri'),
+            reportTo: config('csp.report_to'),
         );
 
         if (! $reportOnlyPolicy->isEmpty()) {

--- a/src/CspMetaTag.php
+++ b/src/CspMetaTag.php
@@ -24,14 +24,14 @@ class CspMetaTag
             if ($reportOnly) {
                 $reportOnlyPolicy = Policy::create(
                     presets: $presets,
-                    reportUri: config('csp.report_uri')
+                    reportTo: config('csp.report_to')
                 );
 
                 return new static(reportOnlyPolicy: $reportOnlyPolicy);
             } else {
                 $policy = Policy::create(
                     presets: $presets,
-                    reportUri: config('csp.report_uri'),
+                    reportTo: config('csp.report_to'),
                 );
 
                 return new static(policy: $policy);
@@ -41,13 +41,13 @@ class CspMetaTag
         $policy = Policy::create(
             presets: config('csp.presets'),
             directives: config('csp.directives'),
-            reportUri: config('csp.report_uri'),
+            reportTo: config('csp.report_to'),
         );
 
         $reportOnlyPolicy = Policy::create(
             presets: config('csp.report_only_presets'),
             directives: config('csp.report_only_directives'),
-            reportUri: config('csp.report_uri'),
+            reportTo: config('csp.report_to'),
         );
 
         return new static($policy, $reportOnlyPolicy);

--- a/src/Directive.php
+++ b/src/Directive.php
@@ -19,7 +19,6 @@ enum Directive: string
     case OBJECT = 'object-src';
     case PLUGIN = 'plugin-types';
     case PREFETCH = 'prefetch-src';
-    case REPORT = 'report-uri';
     case REPORT_TO = 'report-to';
     case REQUIRE_TRUSTED_TYPES_FOR = 'require-trusted-types-for';
     case SANDBOX = 'sandbox';

--- a/src/Policy.php
+++ b/src/Policy.php
@@ -14,7 +14,7 @@ class Policy
     protected array $directives = [];
 
     public function __construct(
-        protected ?string $reportUri = null,
+        protected ?string $reportTo = null,
     ) {
     }
 
@@ -76,9 +76,9 @@ class Policy
         return $this->add($directive, "'nonce-{$nonce}'");
     }
 
-    public function setReportUri(string $reportUri): self
+    public function setReportTo(string $reportTo): self
     {
-        $this->reportUri = $reportUri;
+        $this->reportTo = $reportTo;
 
         return $this;
     }
@@ -92,8 +92,8 @@ class Policy
     {
         $directives = $this->directives;
 
-        if ($this->reportUri) {
-            $directives[Directive::REPORT->value] = [$this->reportUri];
+        if ($this->reportTo) {
+            $directives[Directive::REPORT_TO->value] = [$this->reportTo];
         }
 
         return collect($directives)
@@ -154,7 +154,7 @@ class Policy
     public static function create(
         array $presets = [],
         array $directives = [],
-        ?string $reportUri = null,
+        ?string $reportTo = null,
     ): self {
         $policy = array_reduce($presets, function (Policy $policy, string $className) {
             $preset = app($className);
@@ -166,7 +166,7 @@ class Policy
             $preset->configure($policy);
 
             return $policy;
-        }, new static($reportUri));
+        }, new static($reportTo));
 
         foreach ($directives as [$directive, $contents]) {
             $policy->add($directive, $contents);

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -92,13 +92,13 @@ it('wont set any headers if not enabled in the config', function (): void {
 });
 
 test('a report uri can be set in the config', function (): void {
-    config(['csp.report_uri' => 'https://report-uri.com']);
+    config(['csp.report_to' => 'https://report-uri.com']);
 
     $headers = getResponseHeaders();
 
     $cspHeader = $headers->get('Content-Security-Policy');
 
-    assertStringContainsString('report-uri https://report-uri.com', $cspHeader);
+    assertStringContainsString('report-to https://report-uri.com', $cspHeader);
 });
 
 it('will throw an exception when using an invalid policy class', function (): void {
@@ -418,15 +418,15 @@ it('can use an empty value for a directive', function (): void {
     );
 });
 
-it('can apply report_uri to the report-only CSP policy when configured', function (): void {
+it('can apply report_to to the report-only CSP policy when configured', function (): void {
     config([
         'csp.report_only_presets' => [Basic::class],
-        'csp.report_uri' => 'https://report-uri-report-only.com',
+        'csp.report_to' => 'https://report-uri-report-only.com',
     ]);
 
     $headers = getResponseHeaders();
 
     $reportOnlyHeader = $headers->get('Content-Security-Policy-Report-Only');
 
-    assertStringContainsString('report-uri https://report-uri-report-only.com', $reportOnlyHeader);
+    assertStringContainsString('report-to https://report-uri-report-only.com', $reportOnlyHeader);
 });


### PR DESCRIPTION
Obviously either a breaking change requiring a new version, but that seems simple (and fairly easy migration path) compared to trying to handle both etc.

- [`report-uri` is deprecated](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/report-uri)
- [`report-to` is the new shiny replacement](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/report-to)

Open to direction, or closing if don't want to open this can of worms!


_(one of those "I wish I hadn't looked" things!)_