### PR TITLE
Add report-to support without removing report-uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ return [
     'report_uri' => env('CSP_REPORT_URI', ''),
 
     /*
+     * The name of the reporting endpoint that violations should be sent to.
+     * The endpoint itself must be defined in `reporting_endpoints` below.
+     */
+    'report_to' => env('CSP_REPORT_TO', ''),
+
+    /*
+     * Reporting endpoints that will be sent in the `Reporting-Endpoints` HTTP
+     * header. The keys are the endpoint names that can be referenced from
+     * `report_to` above.
+     */
+    'reporting_endpoints' => [
+        // 'default' => 'https://example.com/csp-reports',
+    ],
+
+    /*
      * Headers will only be added if this setting is set to true.
      */
     'enabled' => env('CSP_ENABLED', true),
@@ -458,7 +473,25 @@ Instead of outright blocking all violations, you can put configure a CSP policy 
 
 #### To an external url
 
-Any violations against the policy can be reported to a given url. You can set that url in the `report_uri` key of the `csp` config file. A great service that is specifically built for handling these violation reports is [http://report-uri.io/](http://report-uri.io/). 
+Any violations against the policy can be reported to a given url. There are two CSP directives for this:
+
+* `report-uri`: the original directive. It is deprecated, but still supported by most browsers. Set the url in the `report_uri` key of the `csp` config file.
+* `report-to`: the modern replacement. It points to a named endpoint defined in the `Reporting-Endpoints` HTTP header. Set the endpoint name in the `report_to` key, and define the endpoint url in the `reporting_endpoints` array.
+
+While the new directive is rolling out across browsers, you can configure both at the same time. Older browsers will use `report-uri`, newer ones will use `report-to`.
+
+```php
+// config/csp.php
+'report_uri' => env('CSP_REPORT_URI', 'https://example.com/csp-reports'),
+
+'report_to' => env('CSP_REPORT_TO', 'default'),
+
+'reporting_endpoints' => [
+    'default' => 'https://example.com/csp-reports',
+],
+```
+
+A great service that is specifically built for handling these violation reports is [http://report-uri.io/](http://report-uri.io/).
 
 ### Testing
 

--- a/config/csp.php
+++ b/config/csp.php
@@ -42,6 +42,23 @@ return [
     'report_uri' => env('CSP_REPORT_URI', ''),
 
     /*
+     * The name of the reporting endpoint that violations should be sent to.
+     * The endpoint itself must be defined in `reporting_endpoints` below.
+     */
+    'report_to' => env('CSP_REPORT_TO', ''),
+
+    /*
+     * Reporting endpoints that will be sent in the `Reporting-Endpoints` HTTP
+     * header. The keys are the endpoint names that can be referenced from
+     * `report_to` above.
+     *
+     * Example: ['default' => 'https://example.com/csp-reports']
+     */
+    'reporting_endpoints' => [
+        //
+    ],
+
+    /*
      * Headers will only be added if this setting is set to true.
      */
     'enabled' => env('CSP_ENABLED', true),

--- a/src/AddCspHeaders.php
+++ b/src/AddCspHeaders.php
@@ -47,6 +47,7 @@ class AddCspHeaders
             presets: config('csp.presets'),
             directives: config('csp.directives'),
             reportUri: config('csp.report_uri'),
+            reportTo: config('csp.report_to'),
         );
 
         if (! $policy->isEmpty()) {
@@ -57,13 +58,36 @@ class AddCspHeaders
             presets: config('csp.report_only_presets'),
             directives: config('csp.report_only_directives'),
             reportUri: config('csp.report_uri'),
+            reportTo: config('csp.report_to'),
         );
 
         if (! $reportOnlyPolicy->isEmpty()) {
             $response->headers->set('Content-Security-Policy-Report-Only', $reportOnlyPolicy->getContents());
         }
 
+        $this->addReportingEndpointsHeader($response);
+
         return $response;
+    }
+
+    protected function addReportingEndpointsHeader(Response $response): void
+    {
+        $endpoints = config('csp.reporting_endpoints');
+
+        if (empty($endpoints) || ! is_array($endpoints)) {
+            return;
+        }
+
+        $value = collect($endpoints)
+            ->map(fn (string $url, string $name) => "{$name}=\"{$url}\"")
+            ->values()
+            ->implode(', ');
+
+        if ($value === '') {
+            return;
+        }
+
+        $response->headers->set('Reporting-Endpoints', $value);
     }
 
     public function hasCspHeader(mixed $response): bool

--- a/src/CspMetaTag.php
+++ b/src/CspMetaTag.php
@@ -24,7 +24,8 @@ class CspMetaTag
             if ($reportOnly) {
                 $reportOnlyPolicy = Policy::create(
                     presets: $presets,
-                    reportUri: config('csp.report_uri')
+                    reportUri: config('csp.report_uri'),
+                    reportTo: config('csp.report_to'),
                 );
 
                 return new static(reportOnlyPolicy: $reportOnlyPolicy);
@@ -32,6 +33,7 @@ class CspMetaTag
                 $policy = Policy::create(
                     presets: $presets,
                     reportUri: config('csp.report_uri'),
+                    reportTo: config('csp.report_to'),
                 );
 
                 return new static(policy: $policy);
@@ -42,12 +44,14 @@ class CspMetaTag
             presets: config('csp.presets'),
             directives: config('csp.directives'),
             reportUri: config('csp.report_uri'),
+            reportTo: config('csp.report_to'),
         );
 
         $reportOnlyPolicy = Policy::create(
             presets: config('csp.report_only_presets'),
             directives: config('csp.report_only_directives'),
             reportUri: config('csp.report_uri'),
+            reportTo: config('csp.report_to'),
         );
 
         return new static($policy, $reportOnlyPolicy);

--- a/src/Policy.php
+++ b/src/Policy.php
@@ -15,6 +15,7 @@ class Policy
 
     public function __construct(
         protected ?string $reportUri = null,
+        protected ?string $reportTo = null,
     ) {
     }
 
@@ -83,6 +84,13 @@ class Policy
         return $this;
     }
 
+    public function setReportTo(string $reportTo): self
+    {
+        $this->reportTo = $reportTo;
+
+        return $this;
+    }
+
     public function isEmpty(): bool
     {
         return empty($this->directives);
@@ -94,6 +102,10 @@ class Policy
 
         if ($this->reportUri) {
             $directives[Directive::REPORT->value] = [$this->reportUri];
+        }
+
+        if ($this->reportTo) {
+            $directives[Directive::REPORT_TO->value] = [$this->reportTo];
         }
 
         return collect($directives)
@@ -155,6 +167,7 @@ class Policy
         array $presets = [],
         array $directives = [],
         ?string $reportUri = null,
+        ?string $reportTo = null,
     ): self {
         $policy = array_reduce($presets, function (Policy $policy, string $className) {
             $preset = app($className);
@@ -166,7 +179,7 @@ class Policy
             $preset->configure($policy);
 
             return $policy;
-        }, new static($reportUri));
+        }, new static($reportUri, $reportTo));
 
         foreach ($directives as [$directive, $contents]) {
             $policy->add($directive, $contents);

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -430,3 +430,60 @@ it('can apply report_uri to the report-only CSP policy when configured', functio
 
     assertStringContainsString('report-uri https://report-uri-report-only.com', $reportOnlyHeader);
 });
+
+test('a report_to endpoint name can be set in the config', function (): void {
+    config(['csp.report_to' => 'csp-endpoint']);
+
+    $headers = getResponseHeaders();
+
+    $cspHeader = $headers->get('Content-Security-Policy');
+
+    assertStringContainsString('report-to csp-endpoint', $cspHeader);
+});
+
+it('emits both report-uri and report-to when both are configured', function (): void {
+    config([
+        'csp.report_uri' => 'https://example.com/csp-reports',
+        'csp.report_to' => 'csp-endpoint',
+    ]);
+
+    $cspHeader = getResponseHeaders()->get('Content-Security-Policy');
+
+    assertStringContainsString('report-uri https://example.com/csp-reports', $cspHeader);
+    assertStringContainsString('report-to csp-endpoint', $cspHeader);
+});
+
+it('adds the Reporting-Endpoints header when reporting_endpoints is configured', function (): void {
+    config([
+        'csp.reporting_endpoints' => [
+            'csp-endpoint' => 'https://example.com/csp-reports',
+            'fallback' => 'https://example.com/fallback',
+        ],
+    ]);
+
+    $reportingEndpoints = getResponseHeaders()->get('Reporting-Endpoints');
+
+    assertEquals(
+        'csp-endpoint="https://example.com/csp-reports", fallback="https://example.com/fallback"',
+        $reportingEndpoints,
+    );
+});
+
+it('does not add the Reporting-Endpoints header when reporting_endpoints is empty', function (): void {
+    config(['csp.reporting_endpoints' => []]);
+
+    $reportingEndpoints = getResponseHeaders()->get('Reporting-Endpoints');
+
+    assertNull($reportingEndpoints);
+});
+
+it('can apply report_to to the report-only CSP policy when configured', function (): void {
+    config([
+        'csp.report_only_presets' => [Basic::class],
+        'csp.report_to' => 'report-only-endpoint',
+    ]);
+
+    $reportOnlyHeader = getResponseHeaders()->get('Content-Security-Policy-Report-Only');
+
+    assertStringContainsString('report-to report-only-endpoint', $reportOnlyHeader);
+});


### PR DESCRIPTION
## Summary

Adds support for the modern `report-to` CSP directive alongside the existing (deprecated, but still widely supported) `report-uri`. Existing config and API surface keep working unchanged, so this is a non-breaking addition.

Alternative to #207, which proposed renaming `report_uri` to `report_to`. A straight rename is breaking, and is also semantically off: `report-to` references a named endpoint defined in the `Reporting-Endpoints` HTTP header, not a URL.

## What's added

* `csp.report_to` config: the name of the reporting endpoint that violations should be sent to via the `report-to` directive.
* `csp.reporting_endpoints` config: a map of endpoint name to URL, emitted as the `Reporting-Endpoints` HTTP response header.
* `Policy::setReportTo(string $name)` and a `reportTo` argument on `Policy::create()`.
* The middleware now adds a `Reporting-Endpoints` header when `reporting_endpoints` is configured, and emits both `report-uri` and `report-to` directives when both are set.

## Migration

Nothing has to change. To adopt the new directive while keeping older browsers working, set both:

```php
// config/csp.php
'report_uri' => env('CSP_REPORT_URI', 'https://example.com/csp-reports'),

'report_to' => env('CSP_REPORT_TO', 'default'),

'reporting_endpoints' => [
    'default' => 'https://example.com/csp-reports',
],
```