### PR TITLE
Add `Directive::IMG:Scheme::DATA` for Bootstrap

### DIFF
--- a/src/Presets/Bootstrap.php
+++ b/src/Presets/Bootstrap.php
@@ -14,6 +14,7 @@ class Bootstrap implements Preset
             ->add([Directive::STYLE, Directive::FONT], [
                 'data:',
                 'https://maxcdn.bootstrapcdn.com',
-            ]);
+            ])
+            ->add(Directive::IMG, Scheme::DATA); // For checkboxes/radios.
     }
 }

--- a/src/Presets/Bootstrap.php
+++ b/src/Presets/Bootstrap.php
@@ -5,6 +5,7 @@ namespace Spatie\Csp\Presets;
 use Spatie\Csp\Directive;
 use Spatie\Csp\Policy;
 use Spatie\Csp\Preset;
+use Spatie\Csp\Scheme;
 
 class Bootstrap implements Preset
 {

--- a/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_Bootstrap______Spatie_Csp_Presets_Bootstrap__.snap
+++ b/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_Bootstrap______Spatie_Csp_Presets_Bootstrap__.snap
@@ -1,2 +1,3 @@
 style-src data: https://maxcdn.bootstrapcdn.com
 font-src data: https://maxcdn.bootstrapcdn.com
+img-src data:


### PR DESCRIPTION
We have this rule, so contributing back. Last PR I hope for a while 🤣 

### Without the rule

<img width="194" height="85" alt="without img-data" src="https://github.com/user-attachments/assets/133d8a3b-4a21-439c-b089-4f58a1b173e2" />

### With it in preset

<img width="201" height="95" alt="with img-data" src="https://github.com/user-attachments/assets/3c9f9276-3153-4348-9b43-a1aaa1d7b44f" />
