### PR TITLE
Support separate report endpoints for the report-only CSP policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,22 @@ return [
     'report_uri' => env('CSP_REPORT_URI', ''),
 
     /*
+     * Optional separate report url for the report-only policy. When empty,
+     * the report-only policy falls back to `report_uri` above.
+     */
+    'report_only_uri' => env('CSP_REPORT_ONLY_URI', ''),
+
+    /*
      * The name of the reporting endpoint that violations should be sent to.
      * The endpoint itself must be defined in `reporting_endpoints` below.
      */
     'report_to' => env('CSP_REPORT_TO', ''),
+
+    /*
+     * Optional separate reporting endpoint name for the report-only policy.
+     * When empty, the report-only policy falls back to `report_to` above.
+     */
+    'report_only_to' => env('CSP_REPORT_ONLY_TO', ''),
 
     /*
      * Reporting endpoints that will be sent in the `Reporting-Endpoints` HTTP
@@ -492,6 +504,16 @@ While the new directive is rolling out across browsers, you can configure both a
 ```
 
 A great service that is specifically built for handling these violation reports is [http://report-uri.io/](http://report-uri.io/).
+
+If you are running an enforcing and a report-only policy side-by-side and need them to report to different endpoints (for example, report-uri.com requires `/enforce` for `Content-Security-Policy` and `/reportOnly` for `Content-Security-Policy-Report-Only`), you can configure `report_only_uri` and/or `report_only_to`:
+
+```php
+// config/csp.php
+'report_uri' => env('CSP_REPORT_URI', 'https://example.report-uri.com/r/d/csp/enforce'),
+'report_only_uri' => env('CSP_REPORT_ONLY_URI', 'https://example.report-uri.com/r/d/csp/reportOnly'),
+```
+
+When `report_only_uri` (or `report_only_to`) is empty, the report-only policy reuses `report_uri` (or `report_to`).
 
 ### Testing
 

--- a/config/csp.php
+++ b/config/csp.php
@@ -42,10 +42,24 @@ return [
     'report_uri' => env('CSP_REPORT_URI', ''),
 
     /*
+     * Optional separate report url for the report-only policy. When empty,
+     * the report-only policy falls back to `report_uri` above. Useful for
+     * services like report-uri.com that require different paths for enforcing
+     * (`/enforce`) and report-only (`/reportOnly`) policies.
+     */
+    'report_only_uri' => env('CSP_REPORT_ONLY_URI', ''),
+
+    /*
      * The name of the reporting endpoint that violations should be sent to.
      * The endpoint itself must be defined in `reporting_endpoints` below.
      */
     'report_to' => env('CSP_REPORT_TO', ''),
+
+    /*
+     * Optional separate reporting endpoint name for the report-only policy.
+     * When empty, the report-only policy falls back to `report_to` above.
+     */
+    'report_only_to' => env('CSP_REPORT_ONLY_TO', ''),
 
     /*
      * Reporting endpoints that will be sent in the `Reporting-Endpoints` HTTP

--- a/src/AddCspHeaders.php
+++ b/src/AddCspHeaders.php
@@ -57,8 +57,8 @@ class AddCspHeaders
         $reportOnlyPolicy = Policy::create(
             presets: config('csp.report_only_presets'),
             directives: config('csp.report_only_directives'),
-            reportUri: config('csp.report_uri'),
-            reportTo: config('csp.report_to'),
+            reportUri: config('csp.report_only_uri') ?: config('csp.report_uri'),
+            reportTo: config('csp.report_only_to') ?: config('csp.report_to'),
         );
 
         if (! $reportOnlyPolicy->isEmpty()) {

--- a/tests/AddCspHeadersTest.php
+++ b/tests/AddCspHeadersTest.php
@@ -487,3 +487,53 @@ it('can apply report_to to the report-only CSP policy when configured', function
 
     assertStringContainsString('report-to report-only-endpoint', $reportOnlyHeader);
 });
+
+it('can set a separate report_only_uri for the report-only policy', function (): void {
+    config([
+        'csp.report_only_presets' => [Basic::class],
+        'csp.report_uri' => 'https://example.com/enforce',
+        'csp.report_only_uri' => 'https://example.com/reportOnly',
+    ]);
+
+    $headers = getResponseHeaders();
+
+    assertStringContainsString('report-uri https://example.com/enforce', $headers->get('Content-Security-Policy'));
+    assertStringContainsString('report-uri https://example.com/reportOnly', $headers->get('Content-Security-Policy-Report-Only'));
+});
+
+it('falls back to report_uri when report_only_uri is empty', function (): void {
+    config([
+        'csp.report_only_presets' => [Basic::class],
+        'csp.report_uri' => 'https://example.com/shared',
+        'csp.report_only_uri' => '',
+    ]);
+
+    $reportOnlyHeader = getResponseHeaders()->get('Content-Security-Policy-Report-Only');
+
+    assertStringContainsString('report-uri https://example.com/shared', $reportOnlyHeader);
+});
+
+it('can set a separate report_only_to for the report-only policy', function (): void {
+    config([
+        'csp.report_only_presets' => [Basic::class],
+        'csp.report_to' => 'enforce-endpoint',
+        'csp.report_only_to' => 'report-only-endpoint',
+    ]);
+
+    $headers = getResponseHeaders();
+
+    assertStringContainsString('report-to enforce-endpoint', $headers->get('Content-Security-Policy'));
+    assertStringContainsString('report-to report-only-endpoint', $headers->get('Content-Security-Policy-Report-Only'));
+});
+
+it('falls back to report_to when report_only_to is empty', function (): void {
+    config([
+        'csp.report_only_presets' => [Basic::class],
+        'csp.report_to' => 'shared-endpoint',
+        'csp.report_only_to' => '',
+    ]);
+
+    $reportOnlyHeader = getResponseHeaders()->get('Content-Security-Policy-Report-Only');
+
+    assertStringContainsString('report-to shared-endpoint', $reportOnlyHeader);
+});


### PR DESCRIPTION
## Summary

Adds two optional config options that let the report-only policy report to a different endpoint than the enforcing policy:

- `report_only_uri` (env `CSP_REPORT_ONLY_URI`) — separate `report-uri` for `Content-Security-Policy-Report-Only`.
- `report_only_to` (env `CSP_REPORT_ONLY_TO`) — separate `report-to` endpoint name for the report-only header.

When either is empty, the report-only policy falls back to `report_uri` / `report_to`, so existing setups are unchanged.

## Motivation

Raised in #210. Services like report-uri.com require distinct paths for the two dispositions:

> You must use the `/enforce` path in a CSP header `report-uri` directive and the `/reportOnly` path in a CSPRO header `report-uri` directive.

Today both headers share a single URL because `AddCspHeaders` passes the same `report_uri` and `report_to` to both `Policy::create()` calls. With this change, a typical report-uri.com setup looks like:

```php
'report_uri' => 'https://example.report-uri.com/r/d/csp/enforce',
'report_only_uri' => 'https://example.report-uri.com/r/d/csp/reportOnly',
```

## Implementation notes

- Only the report-only `Policy::create()` call changes; the enforcing policy is untouched.
- Fallback uses `?:` (not `??`) so an empty string from `env()` defaults correctly resolves to the shared option.
- The `Policy` class itself already supports per-instance report endpoints, so no changes were needed there.
- The `report_to` half is included for parity with `report_uri` since the same limitation applies and the change is symmetric. Happy to drop it if you'd prefer keeping the PR scoped strictly to #210.

## Tests

Four new tests cover both directions:
- separate `report_only_uri` produces different `report-uri` directives on each header
- empty `report_only_uri` falls back to `report_uri`
- same for `report_only_to`

Full suite passes locally (91 tests).