### PR TITLE
Add a There There preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ This package ships with a few commonly used presets to get your started. *We're 
 | `Sentry`                   | [sentry.io](https://sentry.io/)                                                                |
 | `Stripe`                   | [stripe.com](https://stripe.com/)                                                              |
 | `SurveyMonkey`             | [surveymonkey.com](https://www.surveymonkey.com/)                                              |
+| `ThereThere`               | [there-there.app](https://there-there.app) (support bubble widget)                            |
 | `TicketTailor`             | [tickettailor.com](https://www.tickettailor.com)                                               |
 | `Tolt`                     | [tolt.io](https://tolt.io)                                                                     |
 | `TrackJS`                  | [trackjs.com](https://trackjs.com)                                                             |

--- a/src/Presets/ThereThere.php
+++ b/src/Presets/ThereThere.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\Csp\Presets;
+
+use Spatie\Csp\Directive;
+use Spatie\Csp\Keyword;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Preset;
+
+class ThereThere implements Preset
+{
+    // Allows embedding the There There support bubble widget (https://there-there.app).
+    // The loader script is served from files.there-there.app and injects an iframe,
+    // its API/WebSocket traffic, and a small <style> block for the launcher animations.
+    public function configure(Policy $policy): void
+    {
+        $policy
+            ->add(Directive::SCRIPT, 'https://files.there-there.app')
+            ->add(Directive::FRAME, 'https://there-there.app')
+            ->add(Directive::CONNECT, [
+                'https://there-there.app',
+                'wss://there-there.app',
+            ])
+            ->add(Directive::STYLE, Keyword::UNSAFE_INLINE);
+    }
+}

--- a/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_ThereThere______Spatie_Csp_Presets_ThereThere__.snap
+++ b/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_ThereThere______Spatie_Csp_Presets_ThereThere__.snap
@@ -1,0 +1,4 @@
+script-src https://files.there-there.app
+frame-src https://there-there.app
+connect-src https://there-there.app wss://there-there.app
+style-src 'unsafe-inline'

--- a/tests/PresetTest.php
+++ b/tests/PresetTest.php
@@ -55,6 +55,7 @@ it(
     Presets\Sentry::class,
     Presets\Stripe::class,
     Presets\SurveyMonkey::class,
+    Presets\ThereThere::class,
     Presets\TicketTailor::class,
     Presets\Tolt::class,
     Presets\TrackJs::class,


### PR DESCRIPTION
Adds a preset for sites that embed the [There There](https://there-there.app) support bubble widget, so embedders running a CSP can allow it with a single line.

The widget is installed with a one-line `<script>` loader. The loader is served from `files.there-there.app` and injects an iframe (plus its API/WebSocket traffic) served from `there-there.app`, and a small inline `<style>` block for the launcher's entrance/exit animations. This preset allowlists exactly those origins:

```
script-src  https://files.there-there.app
frame-src   https://there-there.app
connect-src https://there-there.app wss://there-there.app
style-src   'unsafe-inline'
```

These are the same directives There There's own install instructions ask embedders to add, so the preset stays in sync with the documented requirements.

Includes the preset class, the `PresetTest` dataset entry + snapshot, and a README table row.