### PR TITLE
Drop roave/security-advisories to unblock CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,7 @@
     "require-dev": {
         "mockery/mockery": "^1.6",
         "orchestra/testbench": "^9.9|^10.0|^11.0",
-        "pestphp/pest": "^3.0|^4.0",
-        "roave/security-advisories": "dev-master"
+        "pestphp/pest": "^3.0|^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`roave/security-advisories` now flags Laravel 11 and Laravel <13.10 as insecure (an `illuminate/mail` advisory), so composer can no longer resolve those matrix combinations and every CI run fails at install. Removing the dev dependency lets the matrix install again. Tests pass unchanged.