### PR TITLE
Remove dead matrix excludes

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,15 +15,6 @@ jobs:
         php: [8.5, 8.4, 8.3]
         laravel: [^11.36.1, ^12, ^13]
         dependency-version: [prefer-lowest, prefer-stable]
-        exclude:
-          - laravel: ^11.36.1
-            php: 8.1
-          - laravel: ^12
-            php: 8.1
-          - laravel: 9.*
-            php: 8.4
-          - laravel: 9.*
-            php: 8.3
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 


### PR DESCRIPTION
The excludes reference `php: 8.1` and `laravel: 9.*`. Neither is in the matrix anymore, so they exclude nothing. Job count is unchanged at 18.