### PR TITLE
Allow blob workers in the Sentry preset

### DIFF
--- a/src/Presets/Sentry.php
+++ b/src/Presets/Sentry.php
@@ -3,8 +3,10 @@
 namespace Spatie\Csp\Presets;
 
 use Spatie\Csp\Directive;
+use Spatie\Csp\Keyword;
 use Spatie\Csp\Policy;
 use Spatie\Csp\Preset;
+use Spatie\Csp\Scheme;
 
 class Sentry implements Preset
 {
@@ -14,6 +16,10 @@ class Sentry implements Preset
             ->add(Directive::CONNECT, [
                 'https://*.ingest.de.sentry.io',
                 'https://*.ingest.us.sentry.io',
+            ])
+            ->add(Directive::WORKER, [
+                Keyword::SELF,
+                Scheme::BLOB, // Session Replay and Browser Profiling spawn their compression worker from a blob URL.
             ]);
     }
 }

--- a/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_Sentry___.snap
+++ b/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_Sentry___.snap
@@ -1,1 +1,2 @@
 connect-src https://*.ingest.de.sentry.io https://*.ingest.us.sentry.io
+worker-src 'self' blob:


### PR DESCRIPTION
## What

Adds `worker-src 'self' blob:` to the `Sentry` preset.

## Why

Sentry's Session Replay and Browser Profiling integrations compress payloads off the main thread. The worker ships as an inlined string, which the SDK wraps in a `Blob` and hands to `new Worker(URL.createObjectURL(blob))`. With the current preset that gets blocked:

> Creating a worker from 'blob:https://example.com/…' violates the following Content Security Policy directive: "worker-src 'self'". The action has been blocked.

The failure is quiet from the app's perspective — replays are either uploaded uncompressed or not captured at all — so it's easy to ship a broken Sentry setup without noticing.

## Note on `'self'`

`worker-src` has no fallback chain once it is present, so adding `blob:` alone would break same-origin workers that previously resolved through `default-src 'self'`. Including `'self'` keeps the preset composable with `Basic`, matching what the `Firebase` preset does. (The `GoogleMaps` preset adds a bare `worker-src blob:` and arguably has this issue, but I've left it out of scope here.)

Snapshot updated; suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018okcgK8XaxhzKPEC8vWkS2