### PR TITLE
Add child-src to the Sentry preset and correct its comment

### DIFF
--- a/src/Presets/Sentry.php
+++ b/src/Presets/Sentry.php
@@ -10,6 +10,10 @@ use Spatie\Csp\Scheme;
 
 class Sentry implements Preset
 {
+    // @see: https://docs.sentry.io/platforms/javascript/session-replay/
+    // Session Replay compresses payloads in a worker created from a blob URL. `child-src` covers
+    // Safari 15.4 and older, which predate `worker-src`. Both list `'self'` because neither
+    // directive falls back to `default-src` once it is present.
     public function configure(Policy $policy): void
     {
         $policy
@@ -17,9 +21,9 @@ class Sentry implements Preset
                 'https://*.ingest.de.sentry.io',
                 'https://*.ingest.us.sentry.io',
             ])
-            ->add(Directive::WORKER, [
+            ->add([Directive::WORKER, Directive::CHILD], [
                 Keyword::SELF,
-                Scheme::BLOB, // Session Replay and Browser Profiling spawn their compression worker from a blob URL.
+                Scheme::BLOB,
             ]);
     }
 }

--- a/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_Sentry___.snap
+++ b/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_Sentry___.snap
@@ -1,2 +1,3 @@
 connect-src https://*.ingest.de.sentry.io https://*.ingest.us.sentry.io
 worker-src 'self' blob:
+child-src 'self' blob:


### PR DESCRIPTION
Follow-up to #222.

Sentry's [Session Replay docs](https://docs.sentry.io/platforms/javascript/session-replay/) prescribe both directives, not just one:

```
worker-src 'self' blob:
child-src 'self' blob:
```

> Safari versions ≤ 15.4 also need `child-src`.

The preset only had `worker-src`, so replay compression stayed blocked on Safari 15.4 and older, which predate `worker-src` and resolve workers through `child-src`.

Also corrects the comment, which claimed Browser Profiling spawns a blob worker. It doesn't. It uses the JS Self-Profiling API and needs a `Document-Policy: js-profiling` response header, which this package can't set.

Worth knowing before merging: declaring `child-src` means it now governs frames for anyone using this preset without an explicit `frame-src`. Combined with `Basic` there is no change, since that sets `frame-src 'self'`.