### PR TITLE
Fix Intercom preset conflicting with Basic preset

### DIFF
--- a/src/Presets/Intercom.php
+++ b/src/Presets/Intercom.php
@@ -11,7 +11,7 @@ class Intercom implements Preset
     public function configure(Policy $policy): void
     {
         $policy
-            ->add(Directive::SCRIPT_ELEM, [
+            ->add(Directive::SCRIPT, [
                 'https://app.intercom.io',
                 'https://widget.intercom.io',
                 'https://js.intercomcdn.com',
@@ -39,7 +39,7 @@ class Intercom implements Preset
                 'https://uploads.eu.intercomcdn.com',
                 'https://uploads.intercomusercontent.com',
             ])
-            ->add(Directive::CHILD, [
+            ->add(Directive::FRAME, [
                 'https://intercom-sheets.com',
                 'https://www.intercom-reporting.com',
                 'https://www.youtube.com',

--- a/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_Intercom___.snap
+++ b/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_Intercom___.snap
@@ -1,6 +1,6 @@
-script-src-elem https://app.intercom.io https://widget.intercom.io https://js.intercomcdn.com
+script-src https://app.intercom.io https://widget.intercom.io https://js.intercomcdn.com
 connect-src https://via.intercom.io https://api.intercom.io https://api.au.intercom.io https://api.eu.intercom.io https://api-iam.intercom.io https://api-iam.eu.intercom.io https://api-iam.au.intercom.io https://api-ping.intercom.io https://nexus-websocket-a.intercom.io wss://nexus-websocket-a.intercom.io https://nexus-websocket-b.intercom.io wss://nexus-websocket-b.intercom.io https://nexus-europe-websocket.intercom.io wss://nexus-europe-websocket.intercom.io https://nexus-australia-websocket.intercom.io wss://nexus-australia-websocket.intercom.io https://uploads.intercomcdn.com https://uploads.intercomcdn.eu https://uploads.au.intercomcdn.com https://uploads.eu.intercomcdn.com https://uploads.intercomusercontent.com
-child-src https://intercom-sheets.com https://www.intercom-reporting.com https://www.youtube.com https://player.vimeo.com https://fast.wistia.net
+frame-src https://intercom-sheets.com https://www.intercom-reporting.com https://www.youtube.com https://player.vimeo.com https://fast.wistia.net
 font-src https://js.intercomcdn.com https://fonts.intercomcdn.com
 form-action https://intercom.help https://api-iam.intercom.io https://api-iam.eu.intercom.io https://api-iam.au.intercom.io
 media-src https://js.intercomcdn.com https://downloads.intercomcdn.com https://downloads.intercomcdn.eu https://downloads.au.intercomcdn.com

--- a/tests/PresetTest.php
+++ b/tests/PresetTest.php
@@ -64,3 +64,18 @@ it(
     Presets\VisualWebsiteOptimizer::class,
     Presets\Whereby::class,
 ]);
+
+it('combines the Basic and Intercom source directives', function (): void {
+    config(['csp.nonce_enabled' => false]);
+
+    $contents = Policy::create([
+        Presets\Basic::class,
+        Presets\Intercom::class,
+    ])->getContents();
+
+    expect($contents)
+        ->toContain("frame-src 'self' https://intercom-sheets.com")
+        ->toContain("script-src 'self' https://app.intercom.io")
+        ->not->toContain('child-src')
+        ->not->toContain('script-src-elem');
+});


### PR DESCRIPTION
When using the Intercom preset together with the Basic preset, some CSP directives conflict with each other.

`Directive::SCRIPT_ELEM` takes precedence over `Directive::SCRIPT` from the Basic preset for <script> elements.

Similarly, `Directive::CHILD` is ignored for frames because `Directive::FRAME`, defined in the Basic preset, takes precedence.