### PR TITLE
Add FONT directive to Cloudflare CDN preset

### DIFF
--- a/src/Presets/CloudflareCdn.php
+++ b/src/Presets/CloudflareCdn.php
@@ -11,7 +11,7 @@ class CloudflareCdn implements Preset
     public function configure(Policy $policy): void
     {
         $policy
-            ->add([Directive::STYLE, Directive::SCRIPT], [
+            ->add([Directive::STYLE, Directive::SCRIPT, Directive::FONT], [
                 'https://cdnjs.cloudflare.com',
             ]);
     }

--- a/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_CloudflareCdn___.snap
+++ b/tests/.pest/snapshots/PresetTest/it_stringifies_with_data_set____Spatie_Csp_Presets_CloudflareCdn___.snap
@@ -1,2 +1,3 @@
 style-src https://cdnjs.cloudflare.com
 script-src https://cdnjs.cloudflare.com
+font-src https://cdnjs.cloudflare.com


### PR DESCRIPTION
Cloudflare CDN can also load fonts.

Example with FontAwesome: https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.3.1/css/all.min.css
This CSS is loading https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.3.1/webfonts/fa-regular-400.woff2